### PR TITLE
[#31] Fix XPaths used in date_order rules at 2.02

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -2,7 +2,7 @@
     "//iati-activity": {
         "atleast_one": {
             "cases": [
-                { "paths": [ "activity-date[@type='1' or @type='2']/@iso-date" ] },
+                { "paths": [ "activity-date[@type='1' or @type='2']" ] },
                 { "paths": [ "sector", "transaction/sector" ] }
             ]
         },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -2,16 +2,16 @@
     "//iati-activity": {
         "atleast_one": {
             "cases": [
-                { "paths": [ "activity-date[@type='1' or @type='2']" ] },
+                { "paths": [ "activity-date[@type='1' or @type='2']/@iso-date" ] },
                 { "paths": [ "sector", "transaction/sector" ] }
             ]
         },
         "date_order": {
             "cases": [
-                { "less": "activity-date[@type='1']", "more": "activity-date[@type='3']" },
-                { "less": "activity-date[@type='2']", "more": "activity-date[@type='4']" },
-                { "less": "activity-date[@type='2']", "more": "NOW" },
-                { "less": "activity-date[@type='4']", "more": "NOW" }
+                { "less": "activity-date[@type='1']/@iso-date", "more": "activity-date[@type='3']/@iso-date" },
+                { "less": "activity-date[@type='2']/@iso-date", "more": "activity-date[@type='4']/@iso-date" },
+                { "less": "activity-date[@type='2']/@iso-date", "more": "NOW" },
+                { "less": "activity-date[@type='4']/@iso-date", "more": "NOW" }
             ]
         },
         "regex_matches": {
@@ -45,64 +45,64 @@
     "//transaction": {
         "date_order": {
             "cases": [
-                { "less": "transaction-date", "more": "NOW" },
-                { "less": "value-date", "more": "NOW" }
+                { "less": "transaction-date/@iso-date", "more": "NOW" },
+                { "less": "value/@value-date", "more": "NOW" }
             ]
         }
     },
     "//planned-disbursement": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     },
     "//budget": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     },
     "//total-budget": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     },
     "//recipient-country-budget": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     },
     "//recipient-org-budget": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     },
     "//recipient-region-budget": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     },
     "//result/indicator/period": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     },
     "//total-expenditure": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     }


### PR DESCRIPTION
The XPaths used in date_order `less` and `more` were previously incorrect
as they did not refer to valid XPaths containing dates at v2.02.