### PR TITLE
[#31] Fix XPaths used in date_order rules at 1.05

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -2,10 +2,10 @@
     "//iati-activity": {
         "date_order": {
             "cases": [
-                { "less": "activity-date[@type='start-actual']", "more": "activity-date[@type='end-actual']" },
-                { "less": "activity-date[@type='start-planned']", "more": "activity-date[@type='end-planned']" },
-                { "less": "activity-date[@type='start-actual']", "more": "NOW" },
-                { "less": "activity-date[@type='end-actual']", "more": "NOW" }
+                { "less": "activity-date[@type='start-actual']/@iso-date", "more": "activity-date[@type='end-actual']/@iso-date" },
+                { "less": "activity-date[@type='start-planned']/@iso-date", "more": "activity-date[@type='end-planned']/@iso-date" },
+                { "less": "activity-date[@type='start-actual']/@iso-date", "more": "NOW" },
+                { "less": "activity-date[@type='end-actual']/@iso-date", "more": "NOW" }
             ]
         },
         "startswith": {
@@ -18,22 +18,22 @@
     "//transaction": {
         "date_order": {
             "cases": [
-                { "less": "transaction-date", "more": "NOW" },
-                { "less": "value-date", "more": "NOW" }
+                { "less": "transaction-date/@iso-date", "more": "NOW" },
+                { "less": "value/@value-date", "more": "NOW" }
             ]
         }
     },
     "//planned-disbursement": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     },
     "//result/indicator/period": {
         "date_order": {
             "cases": [
-                { "less": "period-start", "more": "period-end" }
+                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
         }
     }


### PR DESCRIPTION
The XPaths used in date_order `less` and `more` were previously incorrect
as they did not refer to valid XPaths containing dates at v1.05.