### PR TITLE
[2.02] Fix dateorder text

### DIFF
--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -39,7 +39,7 @@ def rules_text(rules, reduced_path, show_all=False):
                     if case['less'] == 'NOW':
                         out.append('``{0}`` must be in the future.'.format(case['more']))
                     elif case['more'] == 'NOW':
-                        out.append('``{0}`` must be today, or in the past.'.format(case['less']))
+                        out.append('``{0}`` must be in the past.'.format(case['less']))
                     else:
                         out.append('``{0}`` must be before ``{1}``'.format(case['less'], case['more']))
             else: print('Not implemented', case_path, rule, case['paths'])


### PR DESCRIPTION
Fixes #30

The definition of `date_order` at http://iatistandard.org/202/rulesets/ruleset-spec/#rule-names states that `The date matched by less must be less than the date matched by more.`.

This means that today is not a valid value for `less` in this situation since today *is* today, rather than being before (well, `less than`) it.