### PR TITLE
Add Rule to ensure result reference only at one level

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -92,6 +92,13 @@
             ]
         }
     },
+    "//result/indicator": {
+        "no_more_than_one": {
+            "cases": [
+                { "paths": [ "reference", "../reference" ] }
+            ]
+        }
+    },
     "//result/indicator/period": {
         "date_order": {
             "cases": [


### PR DESCRIPTION
The result reference may be either at the result or indicator level, but not both.

This change is to be introduced with 2.03

Fixes #48