### PR TITLE
Make an attribute mandatory when particular codelist values are used

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -99,6 +99,27 @@
             ]
         }
     },
+    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure=='4']/baseline": {
+        "atleast_one": {
+            "cases": [
+                { "paths": [ "@value" ] }
+            ]
+        }
+    },
+    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure=='4']/period/target": {
+        "atleast_one": {
+            "cases": [
+                { "paths": [ "@value" ] }
+            ]
+        }
+    },
+    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure=='4']/period/actual": {
+        "atleast_one": {
+            "cases": [
+                { "paths": [ "@value" ] }
+            ]
+        }
+    },
     "//total-expenditure": {
         "date_order": {
             "cases": [


### PR DESCRIPTION
When indicators are quantitative, a value must be specified.

Several separate Rules are added due to 1:many relationships.

Fixes #51