### PR TITLE
Update regex to match non-whitespace character

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -60,7 +60,7 @@
     "//planned-disbursement/provider-org | //planned-disbursement/receiver-org | //transaction/provider-org | //transaction/receiver-org | //recipient-org-budget/recipient-org": {
         "regex_matches": {
             "cases": [
-                { "regex": "^(?!\s*$).+",
+                { "regex": "^\s*\S.*",
                   "paths": [ "narrative" ], "condition": "count(@ref)==1" }
             ]
         }


### PR DESCRIPTION
As noted by @andylolz in #50, the previous regex wasn't entirely clear.

A clearer regex to check that a string contains a non-whitespace character has been added.