### PR TITLE
Fix and simplify org name regex

### DIFF
--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -95,7 +95,7 @@ def test_rule(context_xpath, element, rule, case):
 
 def test_ruleset_verbose(ruleset, tree):
     for context_xpath, rules in ruleset.items():
-        for element in tree.findall(context_xpath):
+        for element in tree.xpath(context_xpath):
             for rule in rules:
                 cases = rules[rule]['cases']
                 for case in cases:

--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -47,6 +47,7 @@ test regex_no_matches regex_good False
 
 test regex_org_name org_name_good True
 test regex_org_name org_name_bad False
+test regex_org_name org_name_not_relevant True
 
 test starts_with identifiers True
 test starts_with identifiers_bad False

--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -45,6 +45,9 @@ test regex_matches regex_bad False
 test regex_no_matches regex_bad True
 test regex_no_matches regex_good False
 
+test regex_org_name org_name_good True
+test regex_org_name org_name_bad False
+
 test starts_with identifiers True
 test starts_with identifiers_bad False
 

--- a/meta_tests/org_name_bad.xml
+++ b/meta_tests/org_name_bad.xml
@@ -1,0 +1,8 @@
+<iati-activities><iati-activity>
+    <transaction>
+      <provider-org>
+        <narrative>
+        </narrative>
+      </provider-org>
+    </transaction>
+</iati-activity></iati-activities>

--- a/meta_tests/org_name_good.xml
+++ b/meta_tests/org_name_good.xml
@@ -1,0 +1,9 @@
+<iati-activities><iati-activity>
+    <transaction>
+      <provider-org>
+        <narrative>
+          provider org
+        </narrative>
+      </provider-org>
+    </transaction>
+</iati-activity></iati-activities>

--- a/meta_tests/org_name_not_relevant.xml
+++ b/meta_tests/org_name_not_relevant.xml
@@ -1,0 +1,6 @@
+<iati-activities><iati-activity>
+    <transaction>
+      <provider-org ref="abcd">
+      </provider-org>
+    </transaction>
+</iati-activity></iati-activities>

--- a/meta_tests/regex_org_name.json
+++ b/meta_tests/regex_org_name.json
@@ -1,0 +1,10 @@
+{
+    "//transaction/provider-org": {
+        "regex_matches": {
+            "cases": [
+                { "regex": "^(?!\\s*$).+",
+                  "paths": [ "narrative" ], "condition": "count(@ref)==1" }
+            ]
+        }
+    }
+}

--- a/meta_tests/regex_org_name.json
+++ b/meta_tests/regex_org_name.json
@@ -1,5 +1,5 @@
 {
-    "//transaction/provider-org": {
+    "//transaction/provider-org | //transaction/receiver-org": {
         "regex_matches": {
             "cases": [
                 { "regex": "\\S",

--- a/meta_tests/regex_org_name.json
+++ b/meta_tests/regex_org_name.json
@@ -3,7 +3,7 @@
         "regex_matches": {
             "cases": [
                 { "regex": "^(?!\\s*$).+",
-                  "paths": [ "narrative" ], "condition": "count(@ref)==1" }
+                  "paths": [ "narrative" ], "condition": "count(@ref)=1" }
             ]
         }
     }

--- a/meta_tests/regex_org_name.json
+++ b/meta_tests/regex_org_name.json
@@ -2,7 +2,7 @@
     "//transaction/provider-org": {
         "regex_matches": {
             "cases": [
-                { "regex": "^(?!\\s*$).+",
+                { "regex": "\\S",
                   "paths": [ "narrative" ], "condition": "count(@ref)=1" }
             ]
         }

--- a/meta_tests/regex_org_name.json
+++ b/meta_tests/regex_org_name.json
@@ -3,7 +3,7 @@
         "regex_matches": {
             "cases": [
                 { "regex": "\\S",
-                  "paths": [ "narrative" ], "condition": "count(@ref)=1" }
+                  "paths": [ "narrative" ], "condition": "count(@ref)=0" }
             ]
         }
     }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -60,7 +60,7 @@
     "//planned-disbursement/provider-org | //planned-disbursement/receiver-org | //transaction/provider-org | //transaction/receiver-org | //recipient-org-budget/recipient-org": {
         "regex_matches": {
             "cases": [
-                { "regex": "^(?!\\s*$).+",
+                { "regex": "\\S",
                   "paths": [ "narrative" ], "condition": "count(@ref)=1" }
             ]
         }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -60,7 +60,7 @@
     "//planned-disbursement/provider-org | //planned-disbursement/receiver-org | //transaction/provider-org | //transaction/receiver-org | //recipient-org-budget/recipient-org": {
         "regex_matches": {
             "cases": [
-                { "regex": "^(?!\s*$).+",
+                { "regex": "^(?!\\s*$).+",
                   "paths": [ "narrative" ], "condition": "count(@ref)==1" }
             ]
         }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -61,7 +61,7 @@
         "regex_matches": {
             "cases": [
                 { "regex": "^(?!\\s*$).+",
-                  "paths": [ "narrative" ], "condition": "count(@ref)==1" }
+                  "paths": [ "narrative" ], "condition": "count(@ref)=1" }
             ]
         }
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -61,7 +61,7 @@
         "regex_matches": {
             "cases": [
                 { "regex": "\\S",
-                  "paths": [ "narrative" ], "condition": "count(@ref)=1" }
+                  "paths": [ "narrative" ], "condition": "count(@ref)=0" }
             ]
         }
     },


### PR DESCRIPTION
Adds a test that breaks; fixes it.

It’s worth bearing in mind that the regex matcher doesn’t have the `DOTALL` flag set in either [python](https://github.com/IATI/IATI-Rulesets/blob/c33d11885e1084bb99d897c9a5dc3bfcea91c0fb/iatirulesets/__init__.py#L63) or [PHP](https://github.com/IATI/IATI-Rulesets/blob/c33d11885e1084bb99d897c9a5dc3bfcea91c0fb/testrules.php#L93), so you have to be careful when using it for text nodes like `narrative/text()`, that may contain newlines. This actually (sort of) breaks `^(?!\s*$).+`, for instance.

Refs #61.