### PR TITLE
Add a test for the results references rule

### DIFF
--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -25,6 +25,9 @@ test no_more_than_one_title title True
 test no_more_than_one_title empty_activity True
 test no_more_than_one_title title_twice False
 
+test results_references results_refs_good True
+test results_references results_refs_bad False
+
 test dependent_title_description empty_activity True
 test dependent_title_description title False
 test dependent_title_description description False

--- a/meta_tests/results_references.json
+++ b/meta_tests/results_references.json
@@ -1,0 +1,9 @@
+{
+    "//result/indicator": {
+        "no_more_than_one": {
+            "cases": [
+                { "paths": [ "reference", "../reference" ] }
+            ]
+        }
+    }
+}

--- a/meta_tests/results_refs_bad.xml
+++ b/meta_tests/results_refs_bad.xml
@@ -1,0 +1,8 @@
+<iati-activities><iati-activity>
+    <result>
+        <reference />
+        <indicator>
+            <reference />
+        </indicator>
+    </result>
+</iati-activity></iati-activities>

--- a/meta_tests/results_refs_good.xml
+++ b/meta_tests/results_refs_good.xml
@@ -1,0 +1,8 @@
+<iati-activities><iati-activity>
+    <result>
+        <indicator>
+            <reference />
+            <reference />
+        </indicator>
+    </result>
+</iati-activity></iati-activities>


### PR DESCRIPTION
#54 adds untested rules to `version-2.03dev`. This PR adds tests for these new rules, which fail. This should be addressed before merging `version-2.03dev` to `version2.03`.

---

The 2.03 Schema suggests the [`result/reference`](https://github.com/IATI/IATI-Schemas/blob/fa0d7ba693d1a86eef5a8172cecd3f655067c3ea/iati-activities-schema.xsd#L1480) and [`result/indicator/reference`](https://github.com/IATI/IATI-Schemas/blob/fa0d7ba693d1a86eef5a8172cecd3f655067c3ea/iati-activities-schema.xsd#L1525) elements are 0..*. But using multiple `reference`s at either level causes the `no_more_than_one` rule to fail.

Refs #61.