### PR TITLE
Revert "Check that there is a non-empty narrative when there is no ref"

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -57,14 +57,6 @@
             ]
         }
     },
-    "//planned-disbursement/provider-org | //planned-disbursement/receiver-org | //transaction/provider-org | //transaction/receiver-org | //recipient-org-budget/recipient-org": {
-        "regex_matches": {
-            "cases": [
-                { "regex": "^(?!\s*$).+",
-                  "paths": [ "narrative" ], "condition": "count(@ref)==1" }
-            ]
-        }
-    },
     "//budget": {
         "date_order": {
             "cases": [


### PR DESCRIPTION
Reverts IATI/IATI-Rulesets#56

A regex to represent a string containing some non-whitespace character cannot be represented in JSON due to the way backslashes are handled across each regex and JSON.

As such, this Rule is being removed from the set of Machine Actionable Rules since, well, it's not Machine Actionable within the current format!