### PR TITLE
Add tests for multi-clause //result/indicator elements

### DIFF
--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -58,6 +58,10 @@ test condition empty_activity True
 test condition activity_status_2 True
 test condition activity_status_3 False
 
+test multiclause_condition results_value_good True
+test multiclause_condition results_value_bad False
+test multiclause_condition results_value_not_relevant True
+
 # End with a newline
 echo
 

--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -3,10 +3,10 @@ tester=$@
 exitcode=0
 function test() {
     result=`$tester meta_tests/${1}.json meta_tests/${2}.xml --no-breakdown`
-    if [ $result = $3 ]; then echo -n .
+    if [[ $result = $3 ]]; then echo -n .
     else
         echo
-        echo Fail: test $1 $2 $3 
+        echo Fail: test $1 $2 $3
         echo $result
         exitcode=1
     fi
@@ -70,4 +70,3 @@ if [ $exitcode = 0 ]; then
 fi
 
 exit $exitcode
-

--- a/meta_tests/multiclause_condition.json
+++ b/meta_tests/multiclause_condition.json
@@ -1,0 +1,11 @@
+{
+    "//result/indicator": {
+        "atleast_one": {
+            "cases": [
+                { "paths": [ "baseline/@value" ],
+                  "condition": "@measure = 1 or @measure = 2 or @measure = 3 or @measure = 4"
+                }
+            ]
+        }
+    }
+}

--- a/meta_tests/multiclause_condition.json
+++ b/meta_tests/multiclause_condition.json
@@ -1,5 +1,5 @@
 {
-    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure=='4']/baseline": {
+    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/baseline": {
         "atleast_one": {
             "cases": [
                 { "paths": [ "@value" ] }

--- a/meta_tests/multiclause_condition.json
+++ b/meta_tests/multiclause_condition.json
@@ -1,10 +1,8 @@
 {
-    "//result/indicator": {
+    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure=='4']/baseline": {
         "atleast_one": {
             "cases": [
-                { "paths": [ "baseline/@value" ],
-                  "condition": "@measure = 1 or @measure = 2 or @measure = 3 or @measure = 4"
-                }
+                { "paths": [ "@value" ] }
             ]
         }
     }

--- a/meta_tests/results_value_bad.xml
+++ b/meta_tests/results_value_bad.xml
@@ -1,0 +1,3 @@
+<iati-activities><iati-activity>
+    <result><indicator measure="2"><baseline></baseline></indicator></result>
+</iati-activity></iati-activities>

--- a/meta_tests/results_value_good.xml
+++ b/meta_tests/results_value_good.xml
@@ -1,0 +1,3 @@
+<iati-activities><iati-activity>
+    <result><indicator measure="1"><baseline value="1"></baseline></indicator></result>
+</iati-activity></iati-activities>

--- a/meta_tests/results_value_not_relevant.xml
+++ b/meta_tests/results_value_not_relevant.xml
@@ -1,0 +1,3 @@
+<iati-activities><iati-activity>
+    <result><indicator measure="5"><baseline></baseline></indicator></result>
+</iati-activity></iati-activities>

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -106,33 +106,24 @@
             ]
         }
     },
-    "//result/indicator": {
+    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/baseline": {
         "atleast_one": {
             "cases": [
-                {
-                    "paths": [ "baseline/@value" ],
-                    "condition": "@measure = 1 or @measure = 2 or @measure = 3 or @measure = 4"
-                }
+                { "paths": [ "@value" ] }
             ]
         }
     },
-    "//result/indicator": {
+    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/target": {
         "atleast_one": {
             "cases": [
-                {
-                    "paths": [ "period/target/@value" ],
-                    "condition": "@measure = 1 or @measure = 2 or @measure = 3 or @measure = 4"
-                }
+                { "paths": [ "@value" ] }
             ]
         }
     },
-    "//result/indicator": {
+    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/actual": {
         "atleast_one": {
             "cases": [
-                {
-                    "paths": [ "period/actual/@value" ],
-                    "condition": "@measure = 1 or @measure = 2 or @measure = 3 or @measure = 4"
-                }
+                { "paths": [ "@value" ] }
             ]
         }
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -106,24 +106,33 @@
             ]
         }
     },
-    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure=='4']/baseline": {
+    "//result/indicator": {
         "atleast_one": {
             "cases": [
-                { "paths": [ "@value" ] }
+                {
+                    "paths": [ "baseline/@value" ],
+                    "condition": "@measure = 1 or @measure = 2 or @measure = 3 or @measure = 4"
+                }
             ]
         }
     },
-    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure=='4']/period/target": {
+    "//result/indicator": {
         "atleast_one": {
             "cases": [
-                { "paths": [ "@value" ] }
+                {
+                    "paths": [ "period/target/@value" ],
+                    "condition": "@measure = 1 or @measure = 2 or @measure = 3 or @measure = 4"
+                }
             ]
         }
     },
-    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure=='4']/period/actual": {
+    "//result/indicator": {
         "atleast_one": {
             "cases": [
-                { "paths": [ "@value" ] }
+                {
+                    "paths": [ "period/actual/@value" ],
+                    "condition": "@measure = 1 or @measure = 2 or @measure = 3 or @measure = 4"
+                }
             ]
         }
     },


### PR DESCRIPTION
Enhances work done in https://github.com/IATI/IATI-Rulesets/pull/59 by @andylolz (as it seems I'm not able to push to that branch since it is owned a third party)

As mentioned in the original PR, #55 adds untested rules to `version-2.03dev`. This PR adds tests for these new rules, which initially failed. It then patches the bugs, so that the tests pass.

