### PR TITLE
Add text output for no_more_than_one Rule

### DIFF
--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -33,6 +33,9 @@ def rules_text(rules, reduced_path, show_all=False):
                             out.append('``{0}`` should start with the value in ``{1}``'.format(case_path, case['start']))
                         elif rule == 'regex_matches':
                             out.append('``{0}`` should match the regex ``{1}``'.format(case_path, case['regex']))
+                        if rule == 'no_more_than_one':
+                            if other_paths:
+                                out.append('There must be no more than one element or attribute matched at ``{1}`` within each ``{0}``.'.format(case_path, human_list(other_paths, 'or')))
                         elif rule == 'sum':
                             sum_total = case['sum']
                             if other_paths:


### PR DESCRIPTION
A `no_more_than_one` Rule is added at 2.03. This provides something to output as a description of the Rule.
The copy used is the same as in pyIATI for multiple paths.