### PR TITLE
Tidy up human list

### DIFF
--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -31,7 +31,7 @@ def rules_text(rules, reduced_path, show_all=False):
                                 out.append('``{0}`` must not be present if ``{1}`` are present.'.format(case_path, human_list(other_paths)))
                         elif rule == 'atleast_one':
                             if other_paths:
-                                out.append('Either ``{0}`` or ``{1}`` must be present.'.format(case_path, human_list(other_paths)))
+                                out.append('At least one of ``{0}`` must be present.'.format(human_list(case_path, other_paths)))
                             else:
                                 out.append('``{0}`` must be present.'.format(case_path))
                         elif rule == 'startswith':
@@ -46,7 +46,7 @@ def rules_text(rules, reduced_path, show_all=False):
                         elif rule == 'sum':
                             sum_total = case['sum']
                             if other_paths:
-                                out.append('The sum of values matched at ``{0}`` and ``{1}`` must be ``{2}``.'.format(case_path, human_list(other_paths, 'and'), sum_total))
+                                out.append('The sum of values matched at ``{0}`` must be ``{1}``.'.format(human_list(case_path, other_paths, 'and'), sum_total))
                             else:
                                 out.append('The sum of values matched at ``{0}`` must be ``{2}``.'.format(case_path, sum_total))
                         else: print('Not implemented', case_path, rule, case['paths'])

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -2,11 +2,16 @@ from __future__ import print_function
 import re
 import copy
 
-def human_list(other_paths, separator='or'):
+
+def human_list(*args, separator='or'):
+    other_paths = []
+    for x in args:
+        other_paths += x
     if len(other_paths) == 1:
         return other_paths[0]
     else:
         return '`` {0} ``'.format(separator).join(other_paths)
+
 
 def rules_text(rules, reduced_path, show_all=False):
     out = []

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -10,7 +10,9 @@ def human_list(*args, separator='or'):
     if len(other_paths) == 1:
         return other_paths[0]
     else:
-        return '`` {0} ``'.format(separator).join(other_paths)
+        out = '``, ``'.join(other_paths[:-1])
+        out += '`` {1} ``{2}'.format(separator, other_paths[-1])
+        return out
 
 
 def rules_text(rules, reduced_path, show_all=False):

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -3,7 +3,8 @@ import re
 import copy
 
 
-def human_list(*args, separator='or'):
+def human_list(*args, **kwargs):
+    separator = kwargs.get('separator', 'or')
     other_paths = []
     for x in args:
         other_paths += x
@@ -48,7 +49,7 @@ def rules_text(rules, reduced_path, show_all=False):
                         elif rule == 'sum':
                             sum_total = case['sum']
                             if other_paths:
-                                out.append('The sum of values matched at ``{0}`` must be ``{1}``.'.format(human_list(case_path, other_paths, 'and'), sum_total))
+                                out.append('The sum of values matched at ``{0}`` must be ``{1}``.'.format(human_list(case_path, other_paths, separator='and'), sum_total))
                             else:
                                 out.append('The sum of values matched at ``{0}`` must be ``{2}``.'.format(case_path, sum_total))
                         else: print('Not implemented', case_path, rule, case['paths'])


### PR DESCRIPTION
Instead of “x and y and z”, `human_list` should now output “x, y and z”.

It also makes `human_list` accept an arbitrary number of lists, and uses that in cases where there are `other_paths` that need to be combined with `case_path`.