### PR TITLE
Tidy up human_list (v2.03)

### DIFF
--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -6,7 +6,9 @@ def human_list(other_paths, separator='or'):
     if len(other_paths) == 1:
         return other_paths[0]
     else:
-        return '`` {0} ``'.format(separator).join(other_paths)
+        out = '``, ``'.join(other_paths[:-1])
+        out += '`` {0} ``{1}'.format(separator, other_paths[-1])
+        return out
 
 def rules_text(rules, reduced_path, show_all=False):
     out = []

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -28,7 +28,8 @@ def rules_text(rules, reduced_path, show_all=False):
                                 out.append('``{0}`` must not be present if ``{1}`` are present.'.format(case_path, human_list(other_paths)))
                         elif rule == 'atleast_one':
                             if other_paths:
-                                out.append('Either ``{0}`` or ``{1}`` must be present.'.format(case_path, human_list(other_paths)))
+                                all_paths = [case_path] + other_paths
+                                out.append('At least one of ``{0}`` must be present.'.format(human_list(all_paths)))
                             else:
                                 out.append('``{0}`` must be present.'.format(case_path))
                         elif rule == 'startswith':
@@ -43,7 +44,8 @@ def rules_text(rules, reduced_path, show_all=False):
                         elif rule == 'sum':
                             sum_total = case['sum']
                             if other_paths:
-                                out.append('The sum of values matched at ``{0}`` and ``{1}`` must be ``{2}``.'.format(case_path, human_list(other_paths, 'and'), sum_total))
+                                all_paths = [case_path] + other_paths
+                                out.append('The sum of values matched at ``{0}`` must be ``{1}``.'.format(human_list(all_paths, 'and'), sum_total))
                             else:
                                 out.append('The sum of values matched at ``{0}`` must be ``{2}``.'.format(case_path, sum_total))
                         else: print('Not implemented', case_path, rule, case['paths'])


### PR DESCRIPTION
Instead of e.g. “x and y and z”, human_list should now output “x, y and z”.