### PR TITLE
Fix _parse_date code so that it expects a path to a date string, rather than to a date element (v2.03)

### DIFF
--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -44,7 +44,7 @@ class Rules(object):
             date_elements = self.element.xpath(date_xpath)
             if len(date_elements) < 1:
                 return None
-            date_text = date_elements[0].attrib.get('iso-date')
+            date_text = date_elements[0]
             if date_text:
                 m1 = xsDateRegex.match(date_text)
                 return datetime.date(*map(int, m1.groups()))

--- a/meta_tests/date_order.json
+++ b/meta_tests/date_order.json
@@ -2,8 +2,8 @@
     "//iati-activity": {
         "date_order": {
             "cases": [ {
-                "less": "activity-date[@type='start-planned']",
-                "more": "activity-date[@type='end-planned']"
+                "less": "activity-date[@type='start-planned']/@iso-date",
+                "more": "activity-date[@type='end-planned']/@iso-date"
              } ]
         }
     }

--- a/testrules.php
+++ b/testrules.php
@@ -76,10 +76,10 @@ function test_ruleset_dom($rulesets, $doc) {
                     elseif ($rule == 'date_order') {
                         $less_item = $xpath->query($case->less, $element)->item(0);
                         if (!$less_item) continue;
-                        $less = $less_item->getAttribute('iso-date');
+                        $less = $less_item->value;
                         $more_item = $xpath->query($case->more, $element)->item(0);
                         if (!$more_item) continue;
-                        $more = $more_item->getAttribute('iso-date');
+                        $more = $more_item->value;
                         // FIXME
                         // Should probably check that it's an ISO date, as this behaviour differs from
                         // the python implementation (and breaks for the year 10000)


### PR DESCRIPTION
Addresses https://github.com/IATI/IATI-Rulesets/issues/31#issuecomment-395060938:

> While standard.json was updated for all versions to match [the signature pyIATI expects](https://github.com/IATI/pyIATI/blob/59588100911f4fd17a4012c0c2bc9632cc20efbd/iati/rulesets.py#L573) (i.e. a path to a date _*string*_), the relevant code that actually runs the ruleset tests in this repo (that [expects a path to a date _*element*_](https://github.com/IATI/IATI-Rulesets/blob/e77e6860ceba3be71d95c7ed95b9c78f3f29928e/iatirulesets/__init__.py#L40)) wasn’t updated. So this change breaks that.
> 
> The metatests on this repo weren’t updated either, so the green tick on these various PRs is misleading.
> 
> ~~This bug causes lots of errors for IATI-Stats, so it’s worth addressing.~~ UPDATE: Since IATI/IATI-Stats#128, IATI-Stats no longer runs ruleset tests, so it’s no longer affected by this bug.