### PR TITLE
Fix _parse_date code so that it expects a path to a date string, rather than to a date element (v2.01)

### DIFF
--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -44,7 +44,7 @@ class Rules(object):
             date_elements = self.element.xpath(date_xpath)
             if len(date_elements) < 1:
                 return None
-            date_text = date_elements[0].attrib.get('iso-date')
+            date_text = date_elements[0]
             if date_text:
                 m1 = xsDateRegex.match(date_text)
                 return datetime.date(*map(int, m1.groups()))

--- a/meta_tests/date_order.json
+++ b/meta_tests/date_order.json
@@ -2,8 +2,8 @@
     "//iati-activity": {
         "date_order": {
             "cases": [ {
-                "less": "activity-date[@type='start-planned']",
-                "more": "activity-date[@type='end-planned']"
+                "less": "activity-date[@type='start-planned']/@iso-date",
+                "more": "activity-date[@type='end-planned']/@iso-date"
              } ]
         }
     }

--- a/testrules.php
+++ b/testrules.php
@@ -76,10 +76,10 @@ function test_ruleset_dom($rulesets, $doc) {
                     elseif ($rule == 'date_order') {
                         $less_item = $xpath->query($case->less, $element)->item(0);
                         if (!$less_item) continue;
-                        $less = $less_item->getAttribute('iso-date');
+                        $less = $less_item->value;
                         $more_item = $xpath->query($case->more, $element)->item(0);
                         if (!$more_item) continue;
-                        $more = $more_item->getAttribute('iso-date');
+                        $more = $more_item->value;
                         // FIXME
                         // Should probably check that it's an ISO date, as this behaviour differs from
                         // the python implementation (and breaks for the year 10000)


### PR DESCRIPTION
Refs #76.