### PR TITLE
Add sector percentage rule (v2.03)

### DIFF
--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -34,6 +34,9 @@ class Rules(object):
     def unique(self, case):
         return len(self.path_matches_text) <= len(set(self.path_matches_text))
 
+    def strict_sum(self, case):
+        return sum(map(Decimal, map(get_text, self.path_matches))) == Decimal(case['sum'])
+
     def sum(self, case):
         return not(len(self.path_matches)) or sum(map(Decimal, map(get_text, self.path_matches))) == Decimal(case['sum'])
 

--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -37,6 +37,21 @@ class Rules(object):
     def strict_sum(self, case):
         return sum(map(Decimal, map(get_text, self.path_matches))) == Decimal(case['sum'])
 
+    def loop(self, case):
+        for rule, sub_cases in case['do'].items():
+            for sub_case in sub_cases['cases']:
+                subs = {sub: sub_case[sub] for sub in case['subs']}
+                for val in list(set(self.element.xpath(case['foreach']))):
+                    for k, v in subs.items():
+                        if type(v) is list:
+                            sub_case[k] = [vi.replace('$1', val) for vi in v]
+                        else:
+                            sub_case[k] = v.replace('$1', val)
+                    result = test_rule(None, self.element, rule, sub_case)['result']
+                    if not result:
+                        return False
+        return True
+
     def sum(self, case):
         return not(len(self.path_matches)) or sum(map(Decimal, map(get_text, self.path_matches))) == Decimal(case['sum'])
 

--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -39,6 +39,9 @@ test sum sum_bad False
 test sector_percentage_sum sector_percentage_sum_good True
 test sector_percentage_sum sector_percentage_sum_bad False
 
+test forloop forloop_good True
+test forloop forloop_bad False
+
 test sum_two sum_two_good True
 test sum_two sum_two_bad False
 

--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -36,6 +36,9 @@ test dependent_title_description title_description True
 test sum sum_good True
 test sum sum_bad False
 
+test sector_percentage_sum sector_percentage_sum_good True
+test sector_percentage_sum sector_percentage_sum_bad False
+
 test sum_two sum_two_good True
 test sum_two sum_two_bad False
 

--- a/meta_tests/forloop.json
+++ b/meta_tests/forloop.json
@@ -1,0 +1,22 @@
+{
+    "//iati-activity": {
+        "loop": {
+            "cases": [
+                {
+                    "foreach": "sector[@vocabulary != '1']/@vocabulary",
+                    "do": {
+                        "strict_sum": {
+                            "cases": [
+                                {
+                                    "paths": [ "sector[@vocabulary = '$1']/@percentage" ],
+                                    "sum": 100
+                                }
+                            ]
+                        }
+                    },
+                    "subs": ["paths"]
+                }
+            ]
+        }
+    }
+}

--- a/meta_tests/forloop_bad.xml
+++ b/meta_tests/forloop_bad.xml
@@ -1,0 +1,5 @@
+<iati-activities><iati-activity>
+    <sector vocabulary="2" percentage="50"/>
+    <sector vocabulary="2" percentage="60"/>
+    <sector vocabulary="3" percentage="100"/>
+</iati-activity></iati-activities>

--- a/meta_tests/forloop_good.xml
+++ b/meta_tests/forloop_good.xml
@@ -1,0 +1,5 @@
+<iati-activities><iati-activity>
+    <sector vocabulary="2" percentage="50"/>
+    <sector vocabulary="2" percentage="50"/>
+    <sector vocabulary="3" percentage="100"/>
+</iati-activity></iati-activities>

--- a/meta_tests/sector_percentage_sum.json
+++ b/meta_tests/sector_percentage_sum.json
@@ -1,0 +1,12 @@
+{
+    "//iati-activity": {
+        "strict_sum": {
+            "cases": [
+                {
+                    "paths": [ "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage" ],
+                    "sum": 100
+                }
+            ]
+        }
+    }
+}

--- a/meta_tests/sector_percentage_sum_bad.xml
+++ b/meta_tests/sector_percentage_sum_bad.xml
@@ -1,0 +1,4 @@
+<iati-activities><iati-activity>
+    <sector vocabulary="1" percentage="100"/>
+    <sector percentage="100"/>
+</iati-activity></iati-activities>

--- a/meta_tests/sector_percentage_sum_good.xml
+++ b/meta_tests/sector_percentage_sum_good.xml
@@ -1,0 +1,5 @@
+<iati-activities><iati-activity>
+    <sector vocabulary="1" percentage="50"/>
+    <sector percentage="50"/>
+    <sector vocabulary="2" percentage="100"/>
+</iati-activity></iati-activities>

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -26,6 +26,24 @@
                 "sum": 100
              } ]
         },
+        "loop": {
+            "cases": [
+                {
+                    "foreach": "sector[@vocabulary != '1']/@vocabulary",
+                    "do": {
+                        "strict_sum": {
+                            "cases": [
+                                {
+                                    "paths": [ "sector[@vocabulary = '$1']/@percentage" ],
+                                    "sum": 100
+                                }
+                            ]
+                        }
+                    },
+                    "subs": ["paths"]
+                }
+            ]
+        },
         "strict_sum": {
             "cases": [
                 {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -25,6 +25,14 @@
                 "paths": [ "recipient-country/@percentage", "recipient-region/@percentage" ],
                 "sum": 100
              } ]
+        },
+        "strict_sum": {
+            "cases": [
+                {
+                    "paths": [ "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage" ],
+                    "sum": 100
+                }
+            ]
         }
     },
     "//iati-organisation": {

--- a/testrules.php
+++ b/testrules.php
@@ -62,8 +62,8 @@ function test_ruleset_dom($rulesets, $doc) {
                             $errors[] = print_result($xpath_query, $rule, $case);
                         }
                     }
-                    elseif ($rule == 'sum') {
-                        if (count($path_matches) > 0) {
+                    elseif (in_array($rule, array('sum', 'strict_sum'))) {
+                        if ($rule == 'strict_sum' || count($path_matches) > 0) {
                             $sum = 0.0;
                             foreach ($path_matches as $path_match) {
                                 $sum += $path_match->textContent;

--- a/testrules.php
+++ b/testrules.php
@@ -116,6 +116,17 @@ function test_ruleset_dom($rulesets, $doc) {
                             $values[] = $path_match->textContent;
                         }
                     }
+                    elseif ($rule == 'loop') {
+                        $do_copy = $case->do;
+                        foreach ($xpath->query($case->foreach, $element) as $replacement_el) {
+                            $replacement_value = $replacement_el->value;
+                            $subrule_data = json_decode(str_replace('$1', $replacement_value, json_encode($do_copy)));
+                            $sub_ruleset = array($xpath_query => $subrule_data);
+                            $result = test_ruleset_dom($sub_ruleset, $doc);
+                            $errors = $errors + $result['errors'];
+                            $rules_total = $rules_total + $result['rules_total'];
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
PR as per [this discuss thread](https://discuss.iatistandard.org/t/iati-rulesets-add-rules-for-sector-percentages-and-policy-marker-conditionals/1395). Sector percentages for a given vocabulary should add to 100%.

This adds that rule for DAC sector codes. It also adds the rule for other vocabularies, though the implementation (particularly in PHP) is perhaps a bit questionable.

---

Worth noting that for v1.0x, mentions of `@vocabulary = '1'` should be changed to `@vocabulary = 'DAC'`.