### PR TITLE
[2.01] Add date_now rule for last-updated-datetime

### DIFF
--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -81,9 +81,12 @@ class Rules(object):
 
     def date_now(self, case):
         datetime_element = self.element.xpath(case['date'])
-        m1 = xsDateTimeRegex.match(datetime_element[0])
-        mapped_datetime = datetime.datetime(*map(int, m1.groups()))
-        return mapped_datetime < datetime.datetime.now()
+        if len(datetime_element) > 0:
+            m1 = xsDateTimeRegex.match(datetime_element[0])
+            mapped_datetime = datetime.datetime(*map(int, m1.groups()))
+            return mapped_datetime < datetime.datetime.now()
+        else:
+            return None
 
     def _regex_matches(self, case):
         return [ re.search(case['regex'], get_text(path_match)) for path_match in self.path_matches ]

--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -13,6 +13,8 @@ def get_text(element_or_attribute):
         return element_or_attribute
 
 xsDateRegex = re.compile('(-?[0-9]{4,})-([0-9]{2})-([0-9]{2})')
+xsDateTimeRegex = re.compile('(-?[0-9]{4,})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})')
+
 
 class Rules(object):
     def __init__(self, element, case):
@@ -76,6 +78,12 @@ class Rules(object):
             return None
         else:
             return less <= more
+
+    def date_now(self, case):
+        datetime_element = self.element.xpath(case['date'])
+        m1 = xsDateTimeRegex.match(datetime_element[0])
+        mapped_datetime = datetime.datetime(*map(int, m1.groups()))
+        return mapped_datetime < datetime.datetime.now()
 
     def _regex_matches(self, case):
         return [ re.search(case['regex'], get_text(path_match)) for path_match in self.path_matches ]

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -48,6 +48,8 @@ def rules_text(rules, reduced_path, show_all=False):
                         out.append('``{0}`` must not be in the future.'.format(case['less']))
                     else:
                         out.append('``{0}`` must be before or the same as ``{1}``'.format(case['less'], case['more']))
+            elif rule == 'date_now':
+                out.append('``{0}`` must not be more recent than the current date'.format(case['date']))
             else: print('Not implemented', case_path, rule, case['paths'])
     return out
 

--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -58,6 +58,9 @@ test condition empty_activity True
 test condition activity_status_2 True
 test condition activity_status_3 False
 
+test date_now date_now_good True
+test date_now date_now_bad False
+
 # End with a newline
 echo
 

--- a/meta_tests/date_now.json
+++ b/meta_tests/date_now.json
@@ -2,7 +2,7 @@
     "//iati-activity": {
         "date_now": {
             "cases": [
-                { "iati-activity/@last-updated-datetime" }
+                { "@last-updated-datetime" }
             ]
         }
     }

--- a/meta_tests/date_now.json
+++ b/meta_tests/date_now.json
@@ -1,0 +1,9 @@
+{
+    "//iati-activity": {
+        "date_now": {
+            "cases": [
+                { "iati-activity/@last-updated-datetime" }
+            ]
+        }
+    }
+}

--- a/meta_tests/date_now.json
+++ b/meta_tests/date_now.json
@@ -2,7 +2,7 @@
     "//iati-activity": {
         "date_now": {
             "cases": [
-                { "@last-updated-datetime" }
+                { "date":"@last-updated-datetime" }
             ]
         }
     }

--- a/meta_tests/date_now_bad.xml
+++ b/meta_tests/date_now_bad.xml
@@ -1,0 +1,2 @@
+<iati-activities><iati-activity last-updated-datetime="2019-10-24T22:51:42">
+</iati-activity></iati-activities>

--- a/meta_tests/date_now_good.xml
+++ b/meta_tests/date_now_good.xml
@@ -1,0 +1,2 @@
+<iati-activities><iati-activity last-updated-datetime="2018-10-24T22:51:42">
+</iati-activity></iati-activities>

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -6,6 +6,11 @@
                 { "paths": [ "sector", "transaction/sector" ] }
             ]
         },
+        "date_now": {
+            "cases": [
+                { "date": "@last-updated-datetime" }
+            ]
+        },
         "date_order": {
             "cases": [
                 { "less": "activity-date[@type='1']/@iso-date", "more": "activity-date[@type='3']/@iso-date" },

--- a/rulestable.py
+++ b/rulestable.py
@@ -28,7 +28,8 @@ english = {
     'atleast_one': 'Atleast one must be present',
     'sum': 'Must sum to {0}',
     'startswith': 'Must start with ``{0}``',
-    'unique': 'Unique'
+    'unique': 'Unique',
+    'date_now': 'Date must not be more recent than the current date'
 }
 
 for xpath, rules in rulesets.items():

--- a/testrules.php
+++ b/testrules.php
@@ -88,6 +88,15 @@ function test_ruleset_dom($rulesets, $doc) {
                         }
 
                     }
+                    elseif ($rule == 'date_now') {
+                        $update_date = $xpath->query($case->date, $element)->item(0);
+                        if (!$update_date) continue;
+                        $update = $update_date->value;
+                        $current = date("Y-m-d\TH:i:s");
+                        if ($update > $current){
+                            $errors[] = print_result($xpath_query, $rule, $case);
+                        }
+                    }
                     elseif ($rule == 'regex_matches' || $rule == 'regex_no_matches') {
                         foreach($path_matches as $path_match) {
                             $matches = preg_match('/'.$case->regex.'/', $path_match->nodeValue);


### PR DESCRIPTION
Fixes #84, also defines `xsDateTimeRegex` to parse datetimes from the xml files. 