### PR TITLE
[2.01] Schema fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: precise
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -qq python-lxml python3-lxml
-    - npm install -g jsonlint
 script:
     - ./meta_tests.sh python2 testrules.py
     - ./meta_tests.sh python3 testrules.py
-    - jsonlint -q rulesets/standard.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 dist: precise
+language: python
+python:
+    - "2.7"
+    - "3.5"
 before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -qq python-lxml python3-lxml
+install:
+    - pip install jsonschema
+    - pip install -r requirements.txt
 script:
-    - ./meta_tests.sh python2 testrules.py
-    - ./meta_tests.sh python3 testrules.py
+    - python -m jsonschema -i rulesets/standard.json schema.json
+    - ./meta_tests.sh python testrules.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-dist: precise
 language: python
 python:
     - "2.7"

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -94,28 +94,28 @@
                     "paths": [ "crs-add/loan-terms/@rate-1", "crs-add/loan-terms/@rate-2" ]
                 }
             ]
+        },
+        "evaluates_to_true": {
+            "cases": [
+                {"eval": "number(recipient-country/@percentage) >= 0.0"},
+                {"eval": "number(recipient-region/@percentage) >= 0.0"},
+                {"eval": "number(sector/@percentage) >= 0.0"},
+                {"eval": "number(capital-spend/@percentage) >= 0.0"}
+            ]
+        },
+        "if_then": {
+            "cases":[
+                {"if": "count(@lang) = 0", "then": "count(narrative/@lang) > 0 and (count(narrative) = count(narrative/@lang))"},
+                {"if": "count(policy-marker) > 0", "then": "count(policy-marker/@significance) > 0"},
+                {"if": "count(transaction/provider-org/@ref) = 0","then": "count(transaction/provider-org/narrative) > 0"},
+                {"if": "count(@default-currency) = 0", "then": "count(crs-add/loan-status/@currency) > 0"},
+                {"if": "count(@default-currency) = 0", "then": "count(fss/forecast/@currency) > 0"},
+                {"if": "count(transaction/receiver-org/@ref) = 0", "then": "count(transaction/provider-org/narrative) > 0"},
+                {"if": "count(other-identifier/owner-org/@ref) = 0", "then": "count(other-identifier/owner-org/narrative) > 0"},
+                {"if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0", "then": "count(sector/narrative) > 0"},
+                {"if": "count(policy-marker[@vocabulary=99]) > 0", "then": "count(policy-marker/narrative) > 0"}
+            ]
         }
-    },
-    "evaluates_to_true": {
-        "cases": [
-            {"eval": "number(recipient-country/@percentage) >= 0.0"},
-            {"eval": "number(recipient-region/@percentage) >= 0.0"},
-            {"eval": "number(sector/@percentage) >= 0.0"},
-            {"eval": "number(capital-spend/@percentage) >= 0.0"}
-        ]
-    },
-    "if_then": {
-        "cases":[
-            {"if": "count(@lang) = 0", "then": "count(narrative/@lang) > 0 and (count(narrative) = count(narrative/@lang))"},
-            {"if": "count(policy-marker) > 0", "then": "count(policy-marker/@significance) > 0"},
-            {"if": "count(transaction/provider-org/@ref) = 0","then": "count(transaction/provider-org/narrative) > 0"},
-            {"if": "count(@default-currency) = 0", "then": "count(crs-add/loan-status/@currency) > 0"},
-            {"if": "count(@default-currency) = 0", "then": "count(fss/forecast/@currency) > 0"},
-            {"if": "count(transaction/receiver-org/@ref) = 0", "then": "count(transaction/provider-org/narrative) > 0"},
-            {"if": "count(other-identifier/owner-org/@ref) = 0", "then": "count(other-identifier/owner-org/narrative) > 0"},
-            {"if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0", "then": "count(sector/narrative) > 0"},
-            {"if": "count(policy-marker[@vocabulary=99]) > 0", "then": "count(policy-marker/narrative) > 0"}
-        ]
     },
     "//iati-organisation": {
         "regex_matches": {

--- a/schema.json
+++ b/schema.json
@@ -152,32 +152,28 @@
                                 "additionalProperties": false,
                                 "properties": {
                                     "foreach":{
-                                        "type":"array",
-                                        "items":{"type":"string"}
+                                        "type":"string"
                                     },
                                     "do":{
-                                        "type": "array",
-                                        "items": {
-                                            "type": "object",
-                                            "additionalProperties": false,
-                                            "properties": {
-                                                "strict_sum": {
-                                                    "type":"object",
-                                                    "additionalProperties": false,
-                                                    "properties": {
-                                                        "cases":{
-                                                            "type": "array",
-                                                            "items": {
-                                                                "type": "object",
-                                                                "additionalProperties": false,
-                                                                "properties": {
-                                                                    "paths": {
-                                                                        "type": "array",
-                                                                        "items":{"type":"string"}
-                                                                    },
-                                                                    "sum": {
-                                                                        "type": "number"
-                                                                    }
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "strict_sum": {
+                                                "type":"object",
+                                                "additionalProperties": false,
+                                                "properties": {
+                                                    "cases":{
+                                                        "type": "array",
+                                                        "items": {
+                                                            "type": "object",
+                                                            "additionalProperties": false,
+                                                            "properties": {
+                                                                "paths": {
+                                                                    "type": "array",
+                                                                    "items":{"type":"string"}
+                                                                },
+                                                                "sum": {
+                                                                    "type": "number"
                                                                 }
                                                             }
                                                         }

--- a/schema.json
+++ b/schema.json
@@ -176,7 +176,7 @@
                                                                         "items":{"type":"string"}
                                                                     },
                                                                     "sum": {
-                                                                        "type": "number",
+                                                                        "type": "number"
                                                                     }
                                                                 }
                                                             }
@@ -210,7 +210,7 @@
                                         "items":{"type":"string"}
                                     },
                                     "sum": {
-                                        "type": "number",
+                                        "type": "number"
                                     }
                                 }
                             }


### PR DESCRIPTION
#124 does a great job of (amongst other things) bringing schema.json up-to-date. This PR:
 * fixes some small issues to make schema.json valid (f8511e1f; 2c632ae)
 * fixes some small issues (including #128) to make standard.json validate against schema.json (709b1b4)
 * stops running jsonlint on rulesets/standard.json on travis (49545a4), and instead…
 * …makes travis perform schema validation on rulesets/standard.json, using schema.json (3146885)

You might not want to do the last two bits of this, because it could become a bit tiresome being forced to keep schema.json up-to-date (because travis builds will fail otherwise).