### PR TITLE
[2.01] Rearrange standard.json and fine-tune time_limit

### DIFF
--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -116,7 +116,10 @@ class Rules(object):
         if self.element.xpath(case['start']) and self.element.xpath(case['end']):
             start = self._parse_date(case['start'])
             end = self._parse_date(case['end'])
-            return (relativedelta(end, start).years) < 1
+            delta = relativedelta(end, start)
+            if delta.years == 1:
+                return (delta.years + delta.months + delta.days) <= 1
+            return (relativedelta(end, start).years) <= 1
 
     def date_now(self, case):
         datetime_element = self.element.xpath(case['date'])

--- a/meta_tests/between_dates.json
+++ b/meta_tests/between_dates.json
@@ -1,8 +1,8 @@
 {
-    "//iati-organisation": {
+    "//recipient-country-budget": {
         "between_dates": {
             "cases": [
-                { "date": "recipient-country-budget/budget-line/@value-date", "start": "recipient-country-budget/period-start/@iso-date", "end": "recipient-country-budget/period-end/@iso-date"}
+                { "date": "budget-line/value/@value-date", "start": "period-start/@iso-date", "end": "period-end/@iso-date"}
             ]
         }
     }

--- a/meta_tests/between_dates_bad.xml
+++ b/meta_tests/between_dates_bad.xml
@@ -2,6 +2,8 @@
     <recipient-country-budget>
     	<period-start iso-date="2019-01-01"></period-start>
     	<period-end iso-date="2020-01-01"></period-end>
-    	<budget-line value-date="2020-05-01"></budget-line>
+    	<budget-line>
+    		<value value-date="2020-05-01"></value>
+    	</budget-line>
     </recipient-country-budget>
 </iati-organisation></iati-organisations>

--- a/meta_tests/period_time_bad.xml
+++ b/meta_tests/period_time_bad.xml
@@ -1,6 +1,6 @@
 <iati-activities><iati-activity>
     <budget>
     	<period-start iso-date="2019-01-01"></period-start>
-    	<period-end iso-date="2020-01-01"></period-end>
+    	<period-end iso-date="2020-01-02"></period-end>
     </budget>
 </iati-activity></iati-activities>

--- a/meta_tests/time_limit.json
+++ b/meta_tests/time_limit.json
@@ -1,7 +1,7 @@
 {
     "//total-budget": {
 	"time_limit": {
-       	    "cases": [{ "start": "period-start/@iso-date", "end": "period-end/@iso-date"}]
+            "cases": [{ "start": "period-start/@iso-date", "end": "period-end/@iso-date"}]
     	}
     }
 }

--- a/meta_tests/time_limit.json
+++ b/meta_tests/time_limit.json
@@ -1,9 +1,7 @@
 {
     "//total-budget": {
-		"time_limit": {
-       		"cases": [
-            	{ "start": "period-start/@iso-date", "end": "period-end/@iso-date"}
-        	]
+	"time_limit": {
+       	    "cases": [{ "start": "period-start/@iso-date", "end": "period-end/@iso-date"}]
     	}
-	}
+    }
 }

--- a/meta_tests/time_limit.json
+++ b/meta_tests/time_limit.json
@@ -1,12 +1,4 @@
 {
-    "//iati-organisation": {
-        "time_limit": {
-            "cases": [
-                { "start": "recipient-country-budget/period-start/@iso-date", "end": "recipient-country-budget/period-end/@iso-date"},
-                { "start": "recipient-org-budget/period-start/@iso-date", "end": "recipient-org-budget/period-end/@iso-date"},
-            ]
-        }
-    },
     "//total-budget": {
 		"time_limit": {
        		"cases": [

--- a/meta_tests/time_limit.json
+++ b/meta_tests/time_limit.json
@@ -4,8 +4,14 @@
             "cases": [
                 { "start": "recipient-country-budget/period-start/@iso-date", "end": "recipient-country-budget/period-end/@iso-date"},
                 { "start": "recipient-org-budget/period-start/@iso-date", "end": "recipient-org-budget/period-end/@iso-date"},
-                { "start": "total-budget/period-start/@iso-date", "end": "total-budget/period-end/@iso-date"}
             ]
         }
-    }
+    },
+    "//total-budget": {
+		"time_limit": {
+       		"cases": [
+            	{ "start": "period-start/@iso-date", "end": "period-end/@iso-date"}
+        	]
+    	}
+	}
 }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -27,15 +27,6 @@
                 { "date": "@last-updated-datetime" }
             ]
         },
-        "between_dates": {
-            "cases": [
-                { 
-                    "date": "recipient-country-budget/budget-line/@value-date", 
-                    "start": "recipient-country-budget/period-start/@iso-date", 
-                    "end": "recipient-country-budget/period-end/@iso-date"
-                }
-            ]
-        },
         "date_order": {
             "cases": [
                 { "less": "activity-date[@type='1']/@iso-date", "more": "activity-date[@type='3']/@iso-date" },
@@ -183,12 +174,37 @@
             "cases": [
                 { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
             ]
+        },
+        "between_dates": {
+            "cases": [
+                { 
+                    "date": "budget-line/value/@value-date", 
+                    "start": "period-start/@iso-date", 
+                    "end": "period-end/@iso-date"
+                }
+            ]
+        },
+        "time_limit": {
+            "cases": [
+                {
+                    "start": "period-start/@iso-date",
+                    "end": "period-end/@iso-date"
+                }
+            ]
         }
     },
     "//recipient-org-budget": {
         "date_order": {
             "cases": [
                 { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+            ]
+        },
+        "time_limit": {
+            "cases": [
+                {
+                    "start": "period-start/@iso-date",
+                    "end": "period-end/@iso-date"
+                }
             ]
         }
     },


### PR DESCRIPTION
Should address the remaining points on #126, also allows budgets to be EXACTLY one year. @andylolz you are welcome to test against this, just in case I may have missed something else!