### PR TITLE
Ensure percentages are a number between 0 and 100

### DIFF
--- a/meta_tests/evaluates_to_true.json
+++ b/meta_tests/evaluates_to_true.json
@@ -2,7 +2,7 @@
     "//iati-activity": {
         "evaluates_to_true": {
             "cases": [ {
-                "eval": "test/@number >= 0"
+                "eval": "number(test/@number) >= 0.0 and number(test/@number) <= 100.0"
              } ]
         }
     }

--- a/meta_tests/evaluates_to_true_bad.xml
+++ b/meta_tests/evaluates_to_true_bad.xml
@@ -1,3 +1,3 @@
 <iati-activities><iati-activity>
-    <test number="-5.0"/>
+    <test number="110.0"/>
 </iati-activity></iati-activities>

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -84,16 +84,25 @@
         "no_percent": {
             "cases": [
                 {
-                    "paths": [ "crs-add/loan-terms/@rate-1", "crs-add/loan-terms/@rate-2" ]
+                    "paths": [
+                        "crs-add/loan-terms/@rate-1",
+                        "crs-add/loan-terms/@rate-2",
+                        "recipient-country/@percentage",
+                        "recipient-region/@percentage",
+                        "sector/@percentage",
+                        "country-budget-items/budget-item/@percentage",
+                        "capital-spend/@percentage"
+                    ]
                 }
             ]
         },
         "evaluates_to_true": {
             "cases": [
-                {"eval": "number(recipient-country/@percentage) >= 0.0"},
-                {"eval": "number(recipient-region/@percentage) >= 0.0"},
-                {"eval": "number(sector/@percentage) >= 0.0"},
-                {"eval": "number(capital-spend/@percentage) >= 0.0"}
+                {"eval": "number(recipient-country/@percentage) >= 0.0 and number(recipient-country/@percentage) <= 100.0"},
+                {"eval": "number(recipient-region/@percentage) >= 0.0 and number(recipient-region/@percentage) <= 100.0"},
+                {"eval": "number(sector/@percentage) >= 0.0 and number(sector/@percentage) <= 100.0"},
+                {"eval": "number(capital-spend/@percentage) >= 0.0 and number(capital-spend/@percentage) <= 100.0"},
+                {"eval": "number(country-budget-items/budget-item/@percentage) >= 0.0 and number(country-budget-items/budget-item/@percentage) <= 100.0"}
             ]
         },
         "if_then": {


### PR DESCRIPTION
Added more elements to check for no percent sign.
Updated the positive_decimal check to now check the inclusive range between 0.0 and 100.0

Fixes #147