### PR TITLE
Added new quantitative @value rule check

### DIFF
--- a/meta_tests/if_then.json
+++ b/meta_tests/if_then.json
@@ -2,7 +2,8 @@
     "//iati-activity": {
         "if_then": {
             "cases": [ 
-                {"if": "count(test[@example = 1 or @example=2]) > 0", "then": "count(other) > 0"}
+                {"if": "count(test[@example = 1 or @example=2]) > 0", "then": "count(other) > 0"},
+                {"if": "test/@example", "then": "number(test/@example) = test/@example"}
             ]
         }
     }

--- a/meta_tests/if_then_bad.xml
+++ b/meta_tests/if_then_bad.xml
@@ -1,3 +1,4 @@
 <iati-activities><iati-activity>
     <test example="1"></test>
+    <test example="not a number"></test>
 </iati-activity></iati-activities>

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -105,9 +105,9 @@
                 {"if": "count(transaction/receiver-org/@ref) = 0", "then": "count(transaction/provider-org/narrative) > 0"},
                 {"if": "count(other-identifier/owner-org/@ref) = 0", "then": "count(other-identifier/owner-org/narrative) > 0"},
                 {"if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0", "then": "count(sector/narrative) > 0"},
-                {"if": "result/indicator/baseline/@value", "then": "number(result/indicator/baseline/@value) = result/indicator/baseline/@value"},
-                {"if": "result/indicator/period/target/@value", "then": "number(result/indicator/period/target/@value) = result/indicator/period/target/@value"},
-                {"if": "result/indicator/period/actual/@value", "then": "number(result/indicator/period/actual/@value) = result/indicator/period/actual/@value"}
+                {"if": "result/indicator/baseline/@value", "then": "number(result/indicator/baseline/@value) = number(result/indicator/baseline/@value)"},
+                {"if": "result/indicator/period/target/@value", "then": "number(result/indicator/period/target/@value) = number(result/indicator/period/target/@value)"},
+                {"if": "result/indicator/period/actual/@value", "then": "number(result/indicator/period/actual/@value) = number(result/indicator/period/actual/@value)"}
             ]
         }
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -104,7 +104,10 @@
                 {"if": "count(@default-currency) = 0", "then": "count(fss/forecast/@currency) > 0"},
                 {"if": "count(transaction/receiver-org/@ref) = 0", "then": "count(transaction/provider-org/narrative) > 0"},
                 {"if": "count(other-identifier/owner-org/@ref) = 0", "then": "count(other-identifier/owner-org/narrative) > 0"},
-                {"if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0", "then": "count(sector/narrative) > 0"}
+                {"if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0", "then": "count(sector/narrative) > 0"},
+                {"if": "result/indicator/baseline/@value", "then": "number(result/indicator/baseline/@value) = result/indicator/baseline/@value"},
+                {"if": "result/indicator/period/target/@value", "then": "number(result/indicator/period/target/@value) = result/indicator/period/target/@value"},
+                {"if": "result/indicator/period/actual/@value", "then": "number(result/indicator/period/actual/@value) = result/indicator/period/actual/@value"}
             ]
         }
     },


### PR DESCRIPTION
Adds a new set of cases under the `if then` conditions.

Explanation why we check `number() = number()`:

`number(value) = number(value)` is true if `value` is a number, or a string that represents a number.

Whenever `value` cannot be used as a number, then `number(value)` is NaN and NaN is not equal to any other value, even to itself.

The above expression is true only for `value` whose value can be used as a number, and false otherwise.

Simply checking (like I originally did) for `number(value) = value` throws an operator error in XPath2.0, while `number(value)` isn't enough of a test because it checks that `value` is a non-zero numeric item, but we want 0 to be included as well.