### PR TITLE
Fix `@xml:lang` bug (version 2.02)

### DIFF
--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -62,6 +62,7 @@ class Rules(object):
                 for currency in self.element.xpath("descendant::" + cpath):
                     if not currency.xpath("@currency"):
                         return False
+        return True
 
     def dependent(self, case):
         return all(len(m) != 0 for m in self.nested_matches) or all(len(m) == 0 for m in self.nested_matches)

--- a/meta_tests/one_or_all.json
+++ b/meta_tests/one_or_all.json
@@ -2,7 +2,7 @@
     "//iati-activity": {
         "one_or_all": {
             "cases": [
-                { "one":"@xml-lang", "all":"lang" },
+                { "one":"@xml:lang", "all":"lang" },
                 { "one":"sector", "all":"sector" },
                 { "one":"@default-currency", "all":"currency" }
             ]

--- a/meta_tests/one_or_all_lang_good.xml
+++ b/meta_tests/one_or_all_lang_good.xml
@@ -1,4 +1,4 @@
-<iati-activities><iati-activity xml-lang="ES">
+<iati-activities><iati-activity xml:lang="ES">
 	<title>
 		<narrative></narrative>
 	</title>

--- a/meta_tests/one_or_all_org.json
+++ b/meta_tests/one_or_all_org.json
@@ -2,7 +2,7 @@
     "//iati-organisation": {
         "one_or_all": {
             "cases": [
-                { "one":"@xml-lang", "all":"lang" },
+                { "one":"@xml:lang", "all":"lang" },
                 { "one":"@default-currency", "all":"currency" }
             ]
         }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -11,7 +11,7 @@
         },
         "one_or_all": {
             "cases": [
-                { "one":"@xml-lang", "all":"lang" },
+                { "one":"@xml:lang", "all":"lang" },
                 { "one":"sector", "all":"sector" },
                 { "one":"@default-currency", "all":"currency" }
             ]
@@ -140,7 +140,7 @@
         },
         "one_or_all": {
             "cases": [
-                { "one":"@xml-lang", "all":"lang" },
+                { "one":"@xml:lang", "all":"lang" },
                 { "one":"@default-currency", "all":"currency" }
             ]
         }


### PR DESCRIPTION
`@xml-lang` is the wrong attribute name. It should be `@xml:lang`.

This is the same as #179, but for v2.02.