### PR TITLE
Remove python 2.7 from Travis tests (v2.02)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-    - "2.7"
     - "3.5"
 before_install:
     - sudo apt-get update -qq


### PR DESCRIPTION
As part of the process of moving from python 2.x to python 3.x