### PR TITLE
Regex should not match if a bad char is present (version 2.02)

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -42,7 +42,7 @@
 
         "regex_matches": {
             "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
+                { "regex": "^[^\\/\\&\\|\\?]+$",
                   "paths": [ "reporting-org/@ref", "iati-identifier", "participating-org/@ref", "transaction/provider-org/@ref", "transaction/receiver-org/@ref" ] }
             ]
         },
@@ -145,7 +145,7 @@
     "//iati-organisation": {
         "regex_matches": {
             "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
+                { "regex": "^[^\\/\\&\\|\\?]+$",
                   "paths": [ "reporting-org/@ref", "organisation-identifier" ] }
             ]
         },


### PR DESCRIPTION
This replaces #25, which was previously merged.

See [this discuss post](https://discuss.iatistandard.org/t/iati-identifiers-should-not-be-allowed-to-contain-special-characters/649/30) for more details.