### PR TITLE
Regex should not match if a bad char is present (version 2.03)

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -39,7 +39,7 @@
         },
         "regex_matches": {
             "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
+                { "regex": "^[^\\/\\&\\|\\?]+$",
                   "paths": [ "reporting-org/@ref", "iati-identifier", "participating-org/@ref", "transaction/provider-org/@ref", "transaction/receiver-org/@ref" ] }
             ]
         },
@@ -162,7 +162,7 @@
     "//iati-organisation": {
         "regex_matches": {
             "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
+                { "regex": "^[^\\/\\&\\|\\?]+$",
                   "paths": [ "reporting-org/@ref", "organisation-identifier" ] }
             ]
         },


### PR DESCRIPTION
This relates to #25 (which was previously merged.)

See [this discuss post](https://discuss.iatistandard.org/t/iati-identifiers-should-not-be-allowed-to-contain-special-characters/649/30) for more details.