### PR TITLE
Regex should not match if a bad char is present (version 2.01)

### DIFF
--- a/meta_tests/regex_bad.xml
+++ b/meta_tests/regex_bad.xml
@@ -1,3 +1,3 @@
 <iati-activities><iati-activity>
-    <title>ABCD</title>
+    <title>ABC&amp;D</title>
 </iati-activity></iati-activities>

--- a/meta_tests/regex_matches.json
+++ b/meta_tests/regex_matches.json
@@ -3,7 +3,7 @@
         "regex_matches": {
             "cases": [ {
                 "paths": [ "title" ],
-                "regex": "D.D$"
+                "regex": "^[^\\/\\&\\|\\?]+$"
              } ]
         }
     }

--- a/meta_tests/regex_no_matches.json
+++ b/meta_tests/regex_no_matches.json
@@ -3,7 +3,7 @@
         "regex_no_matches": {
             "cases": [ {
                 "paths": [ "title" ],
-                "regex": "D.D$"
+                "regex": "^[^\\/\\&\\|\\?]+$"
              } ]
         }
     }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -42,7 +42,7 @@
 
         "regex_matches": {
             "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
+                { "regex": "^[^\\/\\&\\|\\?]+$",
                   "paths": [ "reporting-org/@ref", "iati-identifier", "participating-org/@ref", "transaction/provider-org/@ref", "transaction/receiver-org/@ref" ] }
             ]
         },
@@ -146,7 +146,7 @@
     "//iati-organisation": {
         "regex_matches": {
             "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
+                { "regex": "^[^\\/\\&\\|\\?]+$",
                   "paths": [ "reporting-org/@ref", "organisation-identifier" ] }
             ]
         },


### PR DESCRIPTION
This relates to #25 (which was previously merged.)

See [this discuss post](https://discuss.iatistandard.org/t/iati-identifiers-should-not-be-allowed-to-contain-special-characters/649/30) for more details.