### PR TITLE
Remove duplicate rules (v2.03)

### DIFF
--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -3,10 +3,7 @@
         "atleast_one": {
             "cases": [
                 { "paths": [ "activity-date[@type='1' or @type='2']" ] },
-                { "paths": [ "sector", "transaction/sector" ] },
-                { "paths": [ "other-identifier/owner-org/@ref", "other-identifier/owner-org/narrative" ] },
-                { "paths": [ "transaction/provider-org/@ref", "transaction/provider-org/narrative" ] },
-                { "paths": [ "transaction/receiver-org/@ref", "transaction/receiver-org/narrative" ] }
+                { "paths": [ "sector", "transaction/sector" ] }
             ]
         },
         "one_or_all": {


### PR DESCRIPTION
These rules:
https://github.com/IATI/IATI-Rulesets/blob/d49b82b821e7ed23d62da1a6767d9dd7cdd310b6/rulesets/standard.json#L7-L9

…have all been replaced by correct versions here:
https://github.com/IATI/IATI-Rulesets/blob/d49b82b821e7ed23d62da1a6767d9dd7cdd310b6/rulesets/standard.json#L127-L147

The original versions haven’t been removed from the v2.03 branch, though. This PR does that.

There’s no need to duplicate this PR for v2.01 or v2.02, since the problem doesn’t exist on those branches.