### PR TITLE
Fix output text for "none of" rules (v2.03)

### DIFF
--- a/iatirulesets/__init__.py
+++ b/iatirulesets/__init__.py
@@ -33,6 +33,9 @@ class Rules(object):
     def atleast_one(self, case):
         return len(self.path_matches) >= 1
 
+    def none_of(self, case):
+        return len(self.path_matches) == 0
+
     def only_one_of(self, case):
         for excluded in case['excluded']:
             if self.element.xpath(excluded):

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -49,7 +49,7 @@ def rules_text(rules, reduced_path, show_all=False):
                             cond = '.' if not cond else ' if ``{0}``'.format(cond)
                             out.append('``{0}`` must not be present{1}'.format(case_path, cond))
                         elif rule == 'only_one_of':
-                            out.append('``{0}`` must not be present alongisde ``{1}``.'.format(case_path, human_list(case['excluded'], 'and')))
+                            out.append('``{0}`` must not be present alongside ``{1}``.'.format(case_path, human_list(case['excluded'], 'and')))
                         elif rule == 'startswith':
                             out.append('``{0}`` should start with the value in ``{1}``'.format(case_path, case['start']))
                         elif rule == 'regex_matches':

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -37,7 +37,7 @@ def rules_text(rules, reduced_path, show_all=False):
                                 break
                         elif rule == 'atleast_one':
                             cond = case.get('condition', None)
-                            cond = '.' if not cond else ' if {}'.format(cond)
+                            cond = '.' if not cond else ' if ``{0}``'.format(cond)
 
                             if other_paths:
                                 out.append('Either ``{0}`` or ``{1}`` must be present{2}'.format(case_path, human_list(other_paths), cond))

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -44,7 +44,10 @@ def rules_text(rules, reduced_path, show_all=False):
                                 break
                             else:
                                 out.append('``{0}`` must be present{1}'.format(case_path, cond))
-
+                        elif rule == 'none_of':
+                            cond = case.get('condition', None)
+                            cond = '.' if not cond else ' if ``{0}``'.format(cond)
+                            out.append('``{0}`` must not be present{1}'.format(case_path, cond))
                         elif rule == 'only_one_of':
                             out.append('``{0}`` must not be present alongisde ``{1}``.'.format(case_path, human_list(case['excluded'], 'and')))
                         elif rule == 'startswith':

--- a/meta_tests.sh
+++ b/meta_tests.sh
@@ -59,6 +59,9 @@ test unique_title_description title_description_content True
 test evaluates_to_true evaluates_to_true_good True
 test evaluates_to_true evaluates_to_true_bad False
 
+test none_of none_of_good True
+test none_of none_of_bad False
+
 test if_then if_then_good True
 test if_then if_then_bad False
 

--- a/meta_tests/none_of.json
+++ b/meta_tests/none_of.json
@@ -1,0 +1,12 @@
+{
+    "//iati-activity": {
+        "none_of": {
+            "cases": [
+                {
+                    "condition": "activity-status/@code='1'",
+                    "paths": ["activity-date[@type='2']"]
+                }
+            ]
+        }
+    }
+}

--- a/meta_tests/none_of_bad.xml
+++ b/meta_tests/none_of_bad.xml
@@ -1,0 +1,4 @@
+<iati-activities><iati-activity>
+    <activity-status code="1"/>
+    <activity-date type="2" iso-date="2014-03-01"/>
+</iati-activity></iati-activities>

--- a/meta_tests/none_of_good.xml
+++ b/meta_tests/none_of_good.xml
@@ -1,0 +1,4 @@
+<iati-activities><iati-activity>
+    <activity-status code="1"/>
+    <activity-date type="1" iso-date="2014-03-01"/>
+</iati-activity></iati-activities>

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -72,19 +72,15 @@
                 }
             ]
         },
-        "evaluates_to_true": {
+        "none_of": {
             "cases": [
                 {
                     "condition": "activity-status/@code='1'",
-                    "eval": "not(activity-date[@type='2'])"
-                },
-                {
-                    "condition": "activity-status/@code='1'",
-                    "eval": "not(activity-date[@type='4'])"
+                    "paths": ["activity-date[@type='2']", "activity-date[@type='4']"]
                 },
                 {
                     "condition": "activity-status/@code='2'",
-                    "eval": "not(activity-date[@type='4'])"
+                    "paths": ["activity-date[@type='4']"]
                 }
             ]
         },

--- a/schema.json
+++ b/schema.json
@@ -50,6 +50,29 @@
                         }
                     }
                 },
+                "none_of": {
+                    "description": "There must be none of the elements described by the given paths.",
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "cases": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "paths": {
+                                        "type": "array",
+                                        "items":{"type":"string"}
+                                    },
+                                    "condition": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
                 "one_or_all": {
                     "description": "One must be present or all of the others must be.",
                     "type": "object",


### PR DESCRIPTION
Fixes #227.

[Demo here](http://227-none-of-iati-rulesets-refbot.surge.sh/activity-standard/iati-activities/iati-activity/activity-date/):

![Screenshot 2019-09-20 at 13 30 25](https://user-images.githubusercontent.com/464193/65327064-d8384380-dbaa-11e9-84d3-6badad4e0a2d.png)
