### PR TITLE
Update codelists and schema used by iati.xslt from sources of truth

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,14 +11,14 @@ IATI-Rulesets
 Introduction
 ============
 
-This is the source repository for the rulesets in the new IATI Validator.
+The master branch of this repository is the source for the rulesets in the `IATI Validator Version 1 <https://github.com/IATI/IATI-Validator-Actual>`_.
 
 As part of the Validator work, the earlier JSON-based rules have been migrated to an XSLT-based system,
 and some additional checks and feedback messages have been added.
 
-* Please see the `main IATI data validator repository <https://github.com/data4development/IATI-data-validator>`_
-  for information about the new IATI Validator and to report bugs, issues, and other feedback.
-* Refer to the `original IATI-Rulesets repository <https://github.com/IATI/IATI-Rulesets>`_ for the original JSON-based rules.
+* Please see the `IATI Validator Actual repository <https://github.com/IATI/IATI-Validator-Actual>`_
+  for information about the IATI Validator Version 1 and to report bugs, issues, and other feedback.
+* Refer to the verion-X.XX branches of this repository for the original JSON-based rules.
 
 Rules
 =====
@@ -33,3 +33,28 @@ Testing the rules
 The `developer` folder contains Xspec scenarios for IATI data with expected messages.
 
 The scenarios can be run using Ant: `ant tests` will run tests and generate an HTML report in `develop/tests/xspec/iati-result.html`.
+
+Keeping Dependencies Updated
+============================
+
+Currently the XSLT transformation relies on Codelists (defined in XML) and Schemas (defined in XSD) contained in the `/lib/schemata` directory of this repository.
+
+These Codelists and Schemas are actively maintained in other repositories.
+
+Codelists
+
+- `IATI/IATI-Codelists <https://github.com/IATI/IATI-Codelists>`_
+
+- `IATI/IATI-Codelists-NonEmbedded <https://github.com/IATI/IATI-Codelists-NonEmbedded>`_
+
+Schemas
+
+- `IATI/IATI-Schemas <https://github.com/IATI/IATI-Schemas>`_
+
+To ensure this repo is up to date with the most recent changes in these repositories you can run the `update_rulesets_lib.sh` script in the `IATI SSOT <https://github.com/IATI/IATI-Standard-SSOT/>`_ repository
+
+This script copies the appropriate Codelists and Schemas into the appropriate `/lib/schemata` subdirectories.
+
+You'll then need to commit to a branch and pull request into the master branch of this repository.
+
+Also note that the Validator stores a copy of this repository in it's build so results will not update in the Validator until a release has been made.

--- a/lib/schemata/1.01/iati-common.xsd
+++ b/lib/schemata/1.01/iati-common.xsd
@@ -18,7 +18,7 @@
 
   <!-- for xml:lang -->
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <!--
       Common elements.

--- a/lib/schemata/1.01/iati-organisations-schema.xsd
+++ b/lib/schemata/1.01/iati-organisations-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-organisations">
     <xsd:annotation>

--- a/lib/schemata/1.01/xml.xsd
+++ b/lib/schemata/1.01/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/lib/schemata/1.02/iati-common.xsd
+++ b/lib/schemata/1.02/iati-common.xsd
@@ -18,7 +18,7 @@
 
   <!-- for xml:lang -->
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <!--
       Common elements.

--- a/lib/schemata/1.02/iati-organisations-schema.xsd
+++ b/lib/schemata/1.02/iati-organisations-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-organisations">
     <xsd:annotation>

--- a/lib/schemata/1.02/xml.xsd
+++ b/lib/schemata/1.02/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/lib/schemata/1.03/iati-common.xsd
+++ b/lib/schemata/1.03/iati-common.xsd
@@ -18,7 +18,7 @@
 
   <!-- for xml:lang -->
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <!--
       Common elements.

--- a/lib/schemata/1.03/iati-organisations-schema.xsd
+++ b/lib/schemata/1.03/iati-organisations-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-organisations">
     <xsd:annotation>

--- a/lib/schemata/1.03/xml.xsd
+++ b/lib/schemata/1.03/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/lib/schemata/1.04/iati-common.xsd
+++ b/lib/schemata/1.04/iati-common.xsd
@@ -18,7 +18,7 @@
 
   <!-- for xml:lang -->
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <!--
       Common elements.

--- a/lib/schemata/1.04/iati-organisations-schema.xsd
+++ b/lib/schemata/1.04/iati-organisations-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-organisations">
     <xsd:annotation>

--- a/lib/schemata/1.04/xml.xsd
+++ b/lib/schemata/1.04/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/lib/schemata/1.05/iati-common.xsd
+++ b/lib/schemata/1.05/iati-common.xsd
@@ -18,7 +18,7 @@
 
   <!-- for xml:lang -->
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <!--
       Common elements.

--- a/lib/schemata/1.05/iati-organisations-schema.xsd
+++ b/lib/schemata/1.05/iati-organisations-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-organisations">
     <xsd:annotation>

--- a/lib/schemata/1.05/xml.xsd
+++ b/lib/schemata/1.05/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/lib/schemata/2.01/iati-common.xsd
+++ b/lib/schemata/2.01/iati-common.xsd
@@ -18,7 +18,7 @@
 
   <!-- for xml:lang -->
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <!--
       Common elements.

--- a/lib/schemata/2.01/iati-organisations-schema.xsd
+++ b/lib/schemata/2.01/iati-organisations-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-organisations">
     <xsd:annotation>

--- a/lib/schemata/2.01/xml.xsd
+++ b/lib/schemata/2.01/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/lib/schemata/2.02/iati-common.xsd
+++ b/lib/schemata/2.02/iati-common.xsd
@@ -18,7 +18,7 @@
 
   <!-- for xml:lang -->
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <!--
       Common elements.

--- a/lib/schemata/2.02/iati-organisations-schema.xsd
+++ b/lib/schemata/2.02/iati-organisations-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-organisations">
     <xsd:annotation>

--- a/lib/schemata/2.02/xml.xsd
+++ b/lib/schemata/2.02/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/lib/schemata/2.03/iati-activities-schema.xsd
+++ b/lib/schemata/2.03/iati-activities-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-activities">
     <xsd:annotation>
@@ -168,7 +168,7 @@
       <xsd:attribute ref="xml:lang">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            A code specifying the default language of text in this activity. It is recommended that wherever possible only codes from ISO 639-1 are used.
+            A code specifying the default language of text in this activity. It is recommended that wherever possible only codes from ISO 639-1 are used. If this is not declared then the xml:lang attribute MUST be specified for each narrative element.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
@@ -214,7 +214,7 @@
       <xsd:attribute name="budget-not-provided" type="xsd:string" use="optional">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            A code indicating the reason why this activity does not contain any iati-activity/budget elements. The value must exist in the BudgetNotProvided codelist.
+            A code indicating the reason why this activity does not contain any iati-activity/budget elements. The attribute MUST only be used when no budget elements are present.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
@@ -356,7 +356,7 @@
       <xsd:attribute name="percentage" use="optional" type="xsd:decimal">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            The percentage of total commitments or total activity budget to this item. Content must be a decimal number between 0 and 100 inclusive, with no percentage sign. Percentages for all reported countries and regions MUST add up to 100.
+            The percentage of total commitments or total activity budget to this item. Content must be a decimal number between 0 and 100 inclusive, with no percentage sign. Percentages for all reported countries and regions within a vocabulary MUST add up to 100.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
@@ -419,7 +419,7 @@
       <xsd:attribute name="percentage" use="optional" type="xsd:decimal">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            The percentage of total commitments or total activity budget to this item. Content must be a decimal number between 0 and 100 inclusive, with no percentage sign. Percentages for all reported countries and regions MUST add up to 100.
+            The percentage of total commitments or total activity budget to this item. Content must be a decimal number between 0 and 100 inclusive, with no percentage sign. Percentages for all reported countries and regions within a vocabulary MUST add up to 100.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
@@ -883,7 +883,7 @@
           <xsd:annotation>
             <xsd:documentation xml:lang="en">
               A description of the policy marker. This MUST ONLY be
-              used where vocabulary = "99 - RO" (the reporting
+              used if vocabulary is 99 (the reporting
               organisation's own marker vocabulary). May be repeated
               for multiple languages.
             </xsd:documentation>
@@ -1210,7 +1210,7 @@
             <xsd:attribute name="code" type="xsd:string"  use="required">
               <xsd:annotation>
                 <xsd:documentation xml:lang="en">
-                  Either an OECD DAC or UN region code. Codelist i determined by vocabulary attribute.
+                  Either an OECD DAC or UN region code. Codelist is determined by vocabulary attribute.
                 </xsd:documentation>
               </xsd:annotation>
             </xsd:attribute>
@@ -1765,7 +1765,7 @@
                   <xsd:attribute name="indicator-uri" use="optional" type="xsd:anyURI">
                     <xsd:annotation>
                       <xsd:documentation xml:lang="en">
-                        The URI where this vocabulary is defined. If the vocabulary is 99 or 98 (reporting organisation), the URI where this internal vocabulary is defined. While this is an optional field it is STRONGLY RECOMMENDED that all publishers use it to ensure that the meaning of their codes are fully understood by data users.
+                        The URI where this vocabulary is defined. If the vocabulary is 99 (reporting organisation), the URI where this internal vocabulary is defined. While this is an optional field it is STRONGLY RECOMMENDED that all publishers use it to ensure that the meaning of their codes are fully understood by data users.
                       </xsd:documentation>
                     </xsd:annotation>
                   </xsd:attribute>
@@ -1799,7 +1799,11 @@
                       <xsd:documentation xml:lang="en">
                         The baseline value.
 
-                        This should be a numeric value if the measure is quantitative.
+                        The @value should be omitted for qualitative measures.
+
+                        The @value must be included for non-qualitative measures.
+
+                        The @value should be a valid number for all non-qualitative measures.
                       </xsd:documentation>
                     </xsd:annotation>
                   </xsd:attribute>
@@ -1861,7 +1865,11 @@
                             <xsd:documentation xml:lang="en">
                               The target value.
 
-                              This should be a numeric value if the measure is quantitative.
+                              The @value should be omitted for qualitative measures.
+
+                              The @value must be included for non-qualitative measures.
+
+                              The @value should be a valid number for all non-qualitative measures.
                             </xsd:documentation>
                           </xsd:annotation>
                         </xsd:attribute>
@@ -1886,7 +1894,11 @@
                             <xsd:documentation xml:lang="en">
                               The actual measure.
 
-                              This should be a numeric value if the measure is quantitative.
+                              The @value should be omitted for qualitative measures.
+                              
+                              The @value must be included for non-qualitative measures.
+
+                              The @value should be a valid number for all non-qualitative measures.
                             </xsd:documentation>
                           </xsd:annotation>
                         </xsd:attribute>
@@ -1988,7 +2000,7 @@
   <xsd:element name="budget">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
-        The value of the aid activity's budget for each financial quarter or year over the lifetime of the activity. The total budget for an activity should be reported as a commitment in the transaction element. The purpose of this element is to provide predictability for recipient planning on an annual basis. The status explains whether the budget being reported is indicative or has been formally committed. The value should appear within the BudgetStatus codelist. If the @status attribute is not present, the budget is assumed to be indicative. While it is useful for the sum of budgets to match the sum of commitments this is not necessarily the case, depending on a publisher's business model and legal frameworks.
+        The value of the activity's budget for each financial quarter or year over the lifetime of the activity. The purpose of this element is to provide predictability for recipient planning on an annual basis. The status explains whether the budget being reported is indicative or has been formally committed. The value should appear within the BudgetStatus codelist. If the @status attribute is not present, the budget is assumed to be indicative. The sum of budgets may or may not match the sum of commitments, depending on a publisher’s business model and legal frameworks.
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType>
@@ -2475,35 +2487,13 @@
       <xsd:annotation>
         <xsd:documentation xml:lang="en">
           A code for the vocabulary aid-type classifications. If omitted the AidType (OECD DAC) codelist is assumed. The code must be a valid value in the AidTypeVocabulary codelist.
+
+          Each selected vocabulary should only be used once for each activity (iati-activity/default-aid-type) or transaction (iati-activity/transaction/aid-type). All activities and/or transactions should contain a code from the DAC Type of Aid Vocabulary. The above guidelines should be converted to rules at the next integer upgrade.
         </xsd:documentation>
       </xsd:annotation>
     </xsd:attribute>
     <xsd:anyAttribute processContents="lax" namespace="##other"/>
   </xsd:complexType>
-
-  <xsd:complexType name="currencyType">
-    <xsd:annotation>
-      <xsd:documentation xml:lang="en">
-        Data type for an element containing a currency value.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:simpleContent>
-      <xsd:extension base="xsd:decimal">
-        <xsd:attribute ref="currency" use="optional"/>
-        <xsd:attribute ref="value-date" use="required"/>
-        <xsd:anyAttribute processContents="lax" namespace="##other"/>
-      </xsd:extension>
-    </xsd:simpleContent>
-  </xsd:complexType>
-
-  <xsd:attribute name="currency" type="xsd:string">
-    <xsd:annotation>
-      <xsd:documentation xml:lang="en">
-        The ISO 4217 alphabetic currency code of the value reported.
-        This is required unless the iati-activity/\@default-currency is present and applies.
-      </xsd:documentation>
-    </xsd:annotation>
-  </xsd:attribute>
 
 <!-- documentLinkResultBase extends documentLinkBase to include the specific definition for the element where it appears as a child of the iati-activity/result element. -->
   <xsd:complexType name="documentLinkResultBase">

--- a/lib/schemata/2.03/iati-common.xsd
+++ b/lib/schemata/2.03/iati-common.xsd
@@ -18,7 +18,7 @@
 
   <!-- for xml:lang -->
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <!--
       Common elements.
@@ -266,5 +266,31 @@
     </xsd:attribute>
     <xsd:anyAttribute processContents="lax" namespace="##other"/>
   </xsd:complexType>
+
+  <xsd:complexType name="currencyType">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        Data type for an element containing a currency value.
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:decimal">
+        <xsd:attribute ref="currency" use="optional"/>
+        <xsd:attribute ref="value-date" use="required"/>
+        <xsd:anyAttribute processContents="lax" namespace="##other"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:attribute name="currency" type="xsd:string">
+    <xsd:annotation>
+      <xsd:documentation xml:lang="en">
+        A three letter ISO 4217 code for the original currency of the
+        amount. This is required for all currency amounts unless
+        the iati-organisation/\@default-currency attribute is
+        specified.
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:attribute>
 
 </xsd:schema>

--- a/lib/schemata/2.03/iati-organisations-schema.xsd
+++ b/lib/schemata/2.03/iati-organisations-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-organisations">
     <xsd:annotation>
@@ -96,7 +96,7 @@
       <xsd:attribute ref="xml:lang">
         <xsd:annotation>
           <xsd:documentation xml:lang="en">
-            A code specifying the default language of text in this organisation. It is recommended that wherever possible only codes from ISO 639-1 are used.
+            A code specifying the default language of text in this organisation. It is recommended that wherever possible only codes from ISO 639-1 are used. If this is not declared then the xml:lang attribute MUST be specified for each narrative element.
           </xsd:documentation>
         </xsd:annotation>
       </xsd:attribute>
@@ -740,36 +740,15 @@
     </xsd:complexType>
   </xsd:element>
 
-  <xsd:complexType name="currencyType">
-    <xsd:annotation>
-      <xsd:documentation xml:lang="en">
-        Data type for an element containing a currency value.
-      </xsd:documentation>
-    </xsd:annotation>
-    <xsd:simpleContent>
-      <xsd:extension base="xsd:decimal">
-        <xsd:attribute ref="currency" use="optional"/>
-        <xsd:attribute ref="value-date" use="required"/>
-        <xsd:anyAttribute processContents="lax" namespace="##other"/>
-      </xsd:extension>
-    </xsd:simpleContent>
-  </xsd:complexType>
-
-  <xsd:attribute name="currency" type="xsd:string">
-    <xsd:annotation>
-      <xsd:documentation xml:lang="en">
-        A three letter ISO 4217 code for the original currency of the
-        amount. This is required for all currency amounts unless
-        the iati-organisation/\@default-currency attribute is
-        specified.
-      </xsd:documentation>
-    </xsd:annotation>
-  </xsd:attribute>
-
   <!-- documentLinkWithReceipientCountry extends documentLinkBase to include the receipient-country sub-element, which is used within the iati-organisations schema -->
   <xsd:complexType name="documentLinkWithReceipientCountry">
     <xsd:complexContent>
       <xsd:extension base="documentLinkBase">
+        <xsd:annotation>
+          <xsd:documentation xml:lang="en">
+            A link to an online, publicly accessible web page or document.
+          </xsd:documentation>
+        </xsd:annotation>
         <xsd:sequence>
           <xsd:element name="recipient-country" minOccurs="0" maxOccurs="unbounded">
             <xsd:annotation>
@@ -793,7 +772,6 @@
               <xsd:anyAttribute processContents="lax" namespace="##other"/>
             </xsd:complexType>
           </xsd:element>
-          <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
         </xsd:sequence>
       </xsd:extension>
     </xsd:complexContent>

--- a/lib/schemata/2.03/xml.xsd
+++ b/lib/schemata/2.03/xml.xsd
@@ -1,0 +1,287 @@
+<?xml version='1.0'?>
+<?xml-stylesheet href="../2008/09/xsd.xsl" type="text/xsl"?>
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns   ="http://www.w3.org/1999/xhtml"
+  xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+    <h1>About the XML namespace</h1>
+
+    <div class="bodytext">
+     <p>
+      This schema document describes the XML namespace, in a form
+      suitable for import by other schema documents.
+     </p>
+     <p>
+      See <a href="http://www.w3.org/XML/1998/namespace.html">
+      http://www.w3.org/XML/1998/namespace.html</a> and
+      <a href="http://www.w3.org/TR/REC-xml">
+      http://www.w3.org/TR/REC-xml</a> for information 
+      about this namespace.
+     </p>
+     <p>
+      Note that local names in this namespace are intended to be
+      defined only by the World Wide Web Consortium or its subgroups.
+      The names currently defined in this namespace are listed below.
+      They should not be used with conflicting semantics by any Working
+      Group, specification, or document instance.
+     </p>
+     <p>   
+      See further below in this document for more information about <a
+      href="#usage">how to refer to this schema document from your own
+      XSD schema documents</a> and about <a href="#nsversioning">the
+      namespace-versioning policy governing this schema document</a>.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>lang (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       is a language code for the natural language of the content of
+       any element; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML specification.</p>
+     
+    </div>
+    <div>
+     <h4>Notes</h4>
+     <p>
+      Attempting to install the relevant ISO 2- and 3-letter
+      codes as the enumerated possible values is probably never
+      going to be a realistic possibility.  
+     </p>
+     <p>
+      See BCP 47 at <a href="http://www.rfc-editor.org/rfc/bcp/bcp47.txt">
+       http://www.rfc-editor.org/rfc/bcp/bcp47.txt</a>
+      and the IANA language subtag registry at
+      <a href="http://www.iana.org/assignments/language-subtag-registry">
+       http://www.iana.org/assignments/language-subtag-registry</a>
+      for further information.
+     </p>
+     <p>
+      The union allows for the 'un-declaration' of xml:lang with
+      the empty string.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:union memberTypes="xs:language">
+    <xs:simpleType>    
+     <xs:restriction base="xs:string">
+      <xs:enumeration value=""/>
+     </xs:restriction>
+    </xs:simpleType>
+   </xs:union>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="space">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>space (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose
+       value is a keyword indicating what whitespace processing
+       discipline is intended for the content of the element; its
+       value is inherited.  This name is reserved by virtue of its
+       definition in the XML specification.</p>
+     
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+ 
+ <xs:attribute name="base" type="xs:anyURI"> <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>base (as an attribute name)</h3>
+      <p>
+       denotes an attribute whose value
+       provides a URI to be used as the base for interpreting any
+       relative URIs in the scope of the element on which it
+       appears; its value is inherited.  This name is reserved
+       by virtue of its definition in the XML Base specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xmlbase/">http://www.w3.org/TR/xmlbase/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+ 
+ <xs:attribute name="id" type="xs:ID">
+  <xs:annotation>
+   <xs:documentation>
+    <div>
+     
+      <h3>id (as an attribute name)</h3> 
+      <p>
+       denotes an attribute whose value
+       should be interpreted as if declared to be of type ID.
+       This name is reserved by virtue of its definition in the
+       xml:id specification.</p>
+     
+     <p>
+      See <a
+      href="http://www.w3.org/TR/xml-id/">http://www.w3.org/TR/xml-id/</a>
+      for information about this attribute.
+     </p>
+    </div>
+   </xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+  <xs:attribute ref="xml:id"/>
+ </xs:attributeGroup>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div>
+   
+    <h3>Father (in any context at all)</h3> 
+
+    <div class="bodytext">
+     <p>
+      denotes Jon Bosak, the chair of 
+      the original XML Working Group.  This name is reserved by 
+      the following decision of the W3C XML Plenary and 
+      XML Coordination groups:
+     </p>
+     <blockquote>
+       <p>
+	In appreciation for his vision, leadership and
+	dedication the W3C XML Plenary on this 10th day of
+	February, 2000, reserves for Jon Bosak in perpetuity
+	the XML name "xml:Father".
+       </p>
+     </blockquote>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div xml:id="usage" id="usage">
+    <h2><a name="usage">About this schema document</a></h2>
+
+    <div class="bodytext">
+     <p>
+      This schema defines attributes and an attribute group suitable
+      for use by schemas wishing to allow <code>xml:base</code>,
+      <code>xml:lang</code>, <code>xml:space</code> or
+      <code>xml:id</code> attributes on elements they define.
+     </p>
+     <p>
+      To enable this, such a schema must import this schema for
+      the XML namespace, e.g. as follows:
+     </p>
+     <pre>
+          &lt;schema . . .>
+           . . .
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+     </pre>
+     <p>
+      or
+     </p>
+     <pre>
+           &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                      schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+     </pre>
+     <p>
+      Subsequently, qualified reference to any of the attributes or the
+      group defined below will have the desired effect, e.g.
+     </p>
+     <pre>
+          &lt;type . . .>
+           . . .
+           &lt;attributeGroup ref="xml:specialAttrs"/>
+     </pre>
+     <p>
+      will define a type which will schema-validate an instance element
+      with any of those attributes.
+     </p>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>
+   <div id="nsversioning" xml:id="nsversioning">
+    <h2><a name="nsversioning">Versioning policy for this schema document</a></h2>
+    <div class="bodytext">
+     <p>
+      In keeping with the XML Schema WG's standard versioning
+      policy, this schema document will persist at
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd</a>.
+     </p>
+     <p>
+      At the date of issue it can also be found at
+      <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd</a>.
+     </p>
+     <p>
+      The schema document at that URI may however change in the future,
+      in order to remain compatible with the latest version of XML
+      Schema itself, or with the XML namespace itself.  In other words,
+      if the XML Schema or XML namespaces change, the version of this
+      document at <a href="http://www.w3.org/2001/xml.xsd">
+       http://www.w3.org/2001/xml.xsd 
+      </a> 
+      will change accordingly; the version at 
+      <a href="http://www.w3.org/2009/01/xml.xsd">
+       http://www.w3.org/2009/01/xml.xsd 
+      </a> 
+      will not change.
+     </p>
+     <p>
+      Previous dated (and unchanging) versions of this schema 
+      document are at:
+     </p>
+     <ul>
+      <li><a href="http://www.w3.org/2009/01/xml.xsd">
+	http://www.w3.org/2009/01/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2007/08/xml.xsd">
+	http://www.w3.org/2007/08/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2004/10/xml.xsd">
+	http://www.w3.org/2004/10/xml.xsd</a></li>
+      <li><a href="http://www.w3.org/2001/03/xml.xsd">
+	http://www.w3.org/2001/03/xml.xsd</a></li>
+     </ul>
+    </div>
+   </div>
+  </xs:documentation>
+ </xs:annotation>
+
+</xs:schema>
+

--- a/lib/schemata/non-embedded-codelist/CRSChannelCode.xml
+++ b/lib/schemata/non-embedded-codelist/CRSChannelCode.xml
@@ -9,2499 +9,4945 @@
         </category>
     </metadata>
     <codelist-items>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active">
             <code>10000</code>
             <name>
-                <narrative>PUBLIC SECTOR INSTITUTIONS</narrative>
-                <narrative xml:lang="fr">INSTITUTIONS DU SECTEUR PUBLIC</narrative>
+                <narrative>Public Sector Institutions</narrative>
+                <narrative xml:lang="fr">Institutions du secteur public</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active">
             <code>11000</code>
             <name>
                 <narrative>Donor Government</narrative>
                 <narrative xml:lang="fr">Gouvernement du donneur</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
+        <codelist-item status="active" activation-date="2015-01-01">
             <code>11001</code>
             <name>
                 <narrative>Central Government</narrative>
                 <narrative xml:lang="fr">Gouvernment central</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>11000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
+        <codelist-item status="active" activation-date="2015-01-01">
             <code>11002</code>
             <name>
                 <narrative>Local Government</narrative>
                 <narrative xml:lang="fr">Gouvernment local</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>11000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
+        <codelist-item status="active" activation-date="2015-01-01">
             <code>11003</code>
             <name>
                 <narrative>Public corporations</narrative>
                 <narrative xml:lang="fr">Entreprise publique</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>11000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
+        <codelist-item status="active" activation-date="2015-01-01">
             <code>11004</code>
             <name>
                 <narrative>Other public entities in donor country</narrative>
                 <narrative xml:lang="fr">Autres entité publique dans le pays donneur</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>11000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active">
             <code>12000</code>
             <name>
                 <narrative>Recipient Government</narrative>
                 <narrative xml:lang="fr">Gouvernement du bénéficiaire</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
+        <codelist-item status="active" activation-date="2015-01-01">
             <code>12001</code>
             <name>
                 <narrative>Central Government</narrative>
                 <narrative xml:lang="fr">Gouvernment central</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>12000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
+        <codelist-item status="active" activation-date="2015-01-01">
             <code>12002</code>
             <name>
                 <narrative>Local Government</narrative>
                 <narrative xml:lang="fr">Gouvernment local</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>12000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
+        <codelist-item status="active" activation-date="2015-01-01">
             <code>12003</code>
             <name>
                 <narrative>Public corporations</narrative>
                 <narrative xml:lang="fr">Entreprise publique</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>12000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
+        <codelist-item status="active" activation-date="2015-01-01">
             <code>12004</code>
             <name>
                 <narrative>Other public entities in recipient country</narrative>
                 <narrative xml:lang="fr">Autres entité publique dans le pays bénéficiaire</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>12000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active">
             <code>13000</code>
             <name>
                 <narrative>Third Country Government (Delegated co-operation)</narrative>
                 <narrative xml:lang="fr">Gouvernement tiers (coopération déléguée)</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active">
             <code>20000</code>
             <name>
-                <narrative>NON-GOVERNMENTAL ORGANISATIONS (NGOs) AND CIVIL SOCIETY</narrative>
-                <narrative xml:lang="fr">ORGANISATIONS NON GOUVERNEMENTALES (ONG) et SOCIÉTÉ CIVILE</narrative>
+                <narrative>Non-Governmental Organisation (NGO) and Civil Society</narrative>
+                <narrative xml:lang="fr">Organisations non gouvernementales (ONG) et société civile</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active">
             <code>21000</code>
             <name>
-                <narrative>INTERNATIONAL NGO</narrative>
-                <narrative xml:lang="fr">ONG INTERNATIONALE</narrative>
+                <narrative>International NGO</narrative>
+                <narrative xml:lang="fr">ONG internationales</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21045</code>
-            <name>
-                <narrative>African Medical and Research Foundation</narrative>
-                <narrative xml:lang="fr">Fondation africaine pour la médecine et la recherche</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21046</code>
-            <name>
-                <narrative>Agency for Cooperation and Research in Development</narrative>
-                <narrative xml:lang="fr">Association de Coopération et de Recherche pour le Développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active" activation-date="1998-01-01">
             <code>21001</code>
             <name>
                 <narrative>Association of Geoscientists for International Development</narrative>
                 <narrative xml:lang="fr">Association de géoscientifiques pour le développement international</narrative>
             </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2017-08-08">
-            <code>21063</code>
-            <name>
-                <narrative>Conservation International</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21005</code>
-            <name>
-                <narrative>Consumer Unity and Trust Society International</narrative>
-                <narrative xml:lang="fr">Consumer Unity and Trust Society International</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21029</code>
-            <name>
-                <narrative>Doctors Without Borders</narrative>
-                <narrative xml:lang="fr">Médecins Sans Frontières</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47035</code>
-            <name>
-                <narrative>Environmental Development Action in the Third World</narrative>
-                <narrative xml:lang="fr">Environnement et développement du Tiers-monde</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21007</code>
-            <name>
-                <narrative>Environmental Liaison Centre International</narrative>
-                <narrative xml:lang="fr">Centre international de liaison pour l’environnement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21503</code>
-            <name>
-                <narrative>Family Health International 360</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21011</code>
-            <name>
-                <narrative>Global Campaign for Education</narrative>
-                <narrative xml:lang="fr">Campagne mondiale pour l’éducation</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21013</code>
-            <name>
-                <narrative>Health Action International</narrative>
-                <narrative xml:lang="fr">Health Action International</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21024</code>
-            <name>
-                <narrative>Inter Press Service, International Association</narrative>
-                <narrative xml:lang="fr">Inter Press Service, International Association</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21038</code>
-            <name>
-                <narrative>International Alert</narrative>
-                <narrative xml:lang="fr">International Alert</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21057</code>
-            <name>
-                <narrative>International Centre for Transitional Justice</narrative>
-                <narrative xml:lang="fr">Centre International pour la Justice Transitionnelle</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21016</code>
-            <name>
-                <narrative>International Committee of the Red Cross</narrative>
-                <narrative xml:lang="fr">Comité international de la Croix-Rouge</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21044</code>
-            <name>
-                <narrative>International Council for the Control of Iodine Deficiency Disorders</narrative>
-                <narrative xml:lang="fr">Conseil international pour la lutte contre les troubles dus à une carence en iode</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21018</code>
-            <name>
-                <narrative>International Federation of Red Cross and Red Crescent Societies</narrative>
-                <narrative xml:lang="fr">Fédération internationale des Sociétés de la Croix-Rouge et du Croissant-Rouge</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21020</code>
-            <name>
-                <narrative>International HIV/AIDS Alliance</narrative>
-                <narrative xml:lang="fr">International HIV/AIDS Alliance</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21022</code>
-            <name>
-                <narrative>International Network for Alternative Financial Institutions</narrative>
-                <narrative xml:lang="fr">Réseau international d’institutions financières</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21042</code>
-            <name>
-                <narrative>International Peacebuilding Alliance</narrative>
-                <narrative xml:lang="fr">Alliance internationale pour la consolidation de la paix</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21023</code>
-            <name>
-                <narrative>International Planned Parenthood Federation</narrative>
-                <narrative xml:lang="fr">Fédération internationale pour le planning familial</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21061</code>
-            <name>
-                <narrative>International Rehabilitation Council for Torture Victims</narrative>
-                <narrative xml:lang="fr">Conseil international de réhabilitation pour les victimes de torture</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21504</code>
-            <name>
-                <narrative>International Relief and Development</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21506</code>
-            <name>
-                <narrative>International Rescue Committee</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21034</code>
-            <name>
-                <narrative>International Union Against Tuberculosis and Lung Disease</narrative>
-                <narrative xml:lang="fr">Union Internationale Contre la Tuberculose et les Maladies Respiratoires</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21053</code>
-            <name>
-                <narrative>IPAS-Protecting Women’s Health, Advancing Women’s Reproductive Rights</narrative>
-                <narrative xml:lang="fr">IPAS-Protecting Womens Health, Advancing Womens Reproductive Rights</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21054</code>
-            <name>
-                <narrative>Life and Peace Institute</narrative>
-                <narrative xml:lang="fr">Institut Vie et Paix</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21501</code>
-            <name>
-                <narrative>OXFAM International</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21507</code>
-            <name>
-                <narrative>Pact World</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21031</code>
-            <name>
-                <narrative>PANOS Institute</narrative>
-                <narrative xml:lang="fr">Institut PANOS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21032</code>
-            <name>
-                <narrative>Population Services International</narrative>
-                <narrative xml:lang="fr">Organisation internationale pour les services en matière de population</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21505</code>
-            <name>
-                <narrative>Save the Children</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21041</code>
-            <name>
-                <narrative>Society for International Development</narrative>
-                <narrative xml:lang="fr">Société pour le développement international</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21062</code>
-            <name>
-                <narrative>The Nature Conservancy</narrative>
-                <narrative xml:lang="fr">The Nature Conservancy</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21036</code>
-            <name>
-                <narrative>World University Service</narrative>
-                <narrative xml:lang="fr">Entraide universitaire mondiale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21502</code>
-            <name>
-                <narrative>World Vision</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>22000</code>
-            <name>
-                <narrative>Donor country-based NGO</narrative>
-                <narrative xml:lang="fr">ONG basée dans un pays donneur</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21047</code>
-            <name>
-                <narrative>AgriCord</narrative>
-                <narrative xml:lang="fr">AgriCord</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21060</code>
-            <name>
-                <narrative>Association for the Prevention of Torture</narrative>
-                <narrative xml:lang="fr">Association pour la prévention de la torture</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21006</code>
-            <name>
-                <narrative>Development Gateway Foundation</narrative>
-                <narrative xml:lang="fr">Development Gateway Foundation</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21049</code>
-            <name>
-                <narrative>European Centre for Development Policy Management</narrative>
-                <narrative xml:lang="fr">Centre européen de gestion de politiques de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21008</code>
-            <name>
-                <narrative>Eurostep</narrative>
-                <narrative xml:lang="fr">Eurostep</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47042</code>
-            <name>
-                <narrative>Foundation for International Training</narrative>
-                <narrative xml:lang="fr">Fondation pour la formation internationale dans les pays du tiers monde</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21050</code>
-            <name>
-                <narrative>Geneva Call</narrative>
-                <narrative xml:lang="fr">Appel de Genève</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21014</code>
-            <name>
-                <narrative>Human Rights Information and Documentation Systems</narrative>
-                <narrative xml:lang="fr">Systèmes d’Information et de Documentation sur les Droits de l’Homme</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21015</code>
-            <name>
-                <narrative>International Catholic Rural Association</narrative>
-                <narrative xml:lang="fr">Association internationale rurale catholique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21058</code>
-            <name>
-                <narrative>International Crisis Group</narrative>
-                <narrative xml:lang="fr">International Crisis Group</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21019</code>
-            <name>
-                <narrative>International Federation of Settlements and Neighbourhood Centres</narrative>
-                <narrative xml:lang="fr">Fédération internationale des centres sociaux et communautaires</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21025</code>
-            <name>
-                <narrative>International Seismological Centre</narrative>
-                <narrative xml:lang="fr">Centre séismologique international</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21026</code>
-            <name>
-                <narrative>International Service for Human Rights</narrative>
-                <narrative xml:lang="fr">Service International pour les Droits de l’Homme</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21027</code>
-            <name>
-                <narrative>ITF Enhancing Human Security</narrative>
-                <narrative xml:lang="fr">ITF Améliorer la sécurité humaine</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21040</code>
-            <name>
-                <narrative>International Women's Tribune Centre</narrative>
-                <narrative xml:lang="fr">Centre de la tribune internationale de la femme</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>22501</code>
-            <name>
-                <narrative>OXFAM - provider country office</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>22502</code>
-            <name>
-                <narrative>Save the Children - donor country office</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21033</code>
-            <name>
-                <narrative>Transparency International</narrative>
-                <narrative xml:lang="fr">Transparency International</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21037</code>
-            <name>
-                <narrative>Women's World Banking</narrative>
-                <narrative xml:lang="fr">Banque mondiale des femmes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21035</code>
-            <name>
-                <narrative>World Organisation Against Torture</narrative>
-                <narrative xml:lang="fr">Organisation mondiale contre la torture</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>23000</code>
-            <name>
-                <narrative>Developing country-based NGO</narrative>
-                <narrative xml:lang="fr">ONG basée dans un pays en développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21059</code>
-            <name>
-                <narrative>Africa Solidarity Fund</narrative>
-                <narrative xml:lang="fr">Fonds solidaire pour l'Afrique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21048</code>
-            <name>
-                <narrative>Association of African Universities</narrative>
-                <narrative xml:lang="fr">Association des universités africaines</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21010</code>
-            <name>
-                <narrative>Forum for African Women Educationalists</narrative>
-                <narrative xml:lang="fr">Forum des éducatrices africaines</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21051</code>
-            <name>
-                <narrative>Institut Supérieur Panafricaine d’Economie Coopérative</narrative>
-                <narrative xml:lang="fr">Institut supérieur panafricaine d’economie coopérative</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21028</code>
-            <name>
-                <narrative>International University Exchange Fund - IUEF Stip. in Africa and Latin America</narrative>
-                <narrative xml:lang="fr">Fonds international d’échanges universitaires - Échanges intéressant l’Afrique et l’Amérique latine</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21003</code>
-            <name>
-                <narrative>Latin American Council for Social Sciences</narrative>
-                <narrative xml:lang="fr">Conseil latino-américain des sciences sociales</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2017-08-08">
-            <code>23501</code>
-            <name>
-                <narrative>National Red Cross and Red Crescent Societies</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21030</code>
-            <name>
-                <narrative>Pan African Institute for Development</narrative>
-                <narrative xml:lang="fr">Institut panafricain pour le développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21055</code>
-            <name>
-                <narrative>Regional AIDS Training Network</narrative>
-                <narrative xml:lang="fr">Réseau régional de formation sur le SIDA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30000</code>
-            <name>
-                <narrative>PUBLIC-PRIVATE PARTNERSHIPS (PPPs) and NETWORKS</narrative>
-                <narrative xml:lang="fr">PARTENARIATS PUBLIC-PRIVÉ ET RÉSEAUX</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>31000</code>
-            <name>
-                <narrative>Public-Private Partnership (PPP)</narrative>
-                <narrative xml:lang="fr">Partenariat public-privé (PPP)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30008</code>
-            <name>
-                <narrative>Cities Alliance</narrative>
-                <narrative xml:lang="fr">Alliance pour les villes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30016</code>
-            <name>
-                <narrative>European Fund for Southeast Europe</narrative>
-                <narrative xml:lang="fr">European Fund for Southeast Europe</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30007</code>
-            <name>
-                <narrative>Global Alliance for ICT and Development</narrative>
-                <narrative xml:lang="fr">Alliance mondiale pour les TIC et le développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30001</code>
-            <name>
-                <narrative>Global Alliance for Improved Nutrition</narrative>
-                <narrative xml:lang="fr">Alliance mondiale pour une meilleure nutrition</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30012</code>
-            <name>
-                <narrative>Global Climate Partnership Fund</narrative>
-                <narrative xml:lang="fr">Global Climate Partnership Fund</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47043</code>
-            <name>
-                <narrative>Global Crop Diversity Trust</narrative>
-                <narrative xml:lang="fr">Global Crop Diversity Trust</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30015</code>
-            <name>
-                <narrative>Global Energy Efficiency and Renewable Energy Fund</narrative>
-                <narrative xml:lang="fr">Fonds mondial pour la promotion de l'efficacité énergétique et des énergies renouvelables</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30003</code>
-            <name>
-                <narrative>Global e-Schools and Communities Initiative</narrative>
-                <narrative xml:lang="fr">Initiative mondiale en faveur de l’informatique dans les écoles et dans les communautés</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30004</code>
-            <name>
-                <narrative>Global Water Partnership</narrative>
-                <narrative xml:lang="fr">Partenariat mondial pour l'eau</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30005</code>
-            <name>
-                <narrative>International AIDS Vaccine Initiative</narrative>
-                <narrative xml:lang="fr">Initiative internationale pour un vaccin contre le SIDA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30006</code>
-            <name>
-                <narrative>International Partnership on Microbicides</narrative>
-                <narrative xml:lang="fr">Partenariat international pour des microbicides</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30011</code>
-            <name>
-                <narrative>International Union for the Conservation of Nature</narrative>
-                <narrative xml:lang="fr">Union internationale pour la conservation de la nature</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30013</code>
-            <name>
-                <narrative>Microfinance Enhancement Facility</narrative>
-                <narrative xml:lang="fr">Mécanisme de soutien au microfinancement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30014</code>
-            <name>
-                <narrative>Regional Micro, Small and Medium Enterprise Investment Fund for Sub-Saharan Africa</narrative>
-                <narrative xml:lang="fr">Fonds régional d’investissement pour les très petites, petites et moyennes entreprises d’Afrique subsaharienne</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21056</code>
-            <name>
-                <narrative>Renewable Energy and Energy Efficiency Partnership</narrative>
-                <narrative xml:lang="fr">Partenariat pour les énergies renouvelables et l'efficience énergétique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30017</code>
-            <name>
-                <narrative>SANAD Fund for Micro, Small and Medium Enterprises</narrative>
-                <narrative xml:lang="fr">SANAD Fund for Micro, Small and Medium Enterprises</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30009</code>
-            <name>
-                <narrative>Small Arms Survey</narrative>
-                <narrative xml:lang="fr">Small Arms Survey</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>32000</code>
-            <name>
-                <narrative>Network</narrative>
-                <narrative xml:lang="fr">RÉSEAU</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47010</code>
-            <name>
-                <narrative>Commonwealth Agency for Public Administration and Management</narrative>
-                <narrative xml:lang="fr">Agence du Commonwealth pour l'administration et la gestion publiques</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47028</code>
-            <name>
-                <narrative>Commonwealth Partnership for Technical Management</narrative>
-                <narrative xml:lang="fr">Partenariat pour la gestion technique (Commonwealth)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21043</code>
-            <name>
-                <narrative>European Parliamentarians for Africa</narrative>
-                <narrative xml:lang="fr">Association des parlementaires d’Europe pour l’Afrique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>31004</code>
-            <name>
-                <narrative>Extractive Industries Transparency Initiative International Secretariat</narrative>
-                <narrative xml:lang="fr">Secrétariat de l'Initiative pour la transparence dans les industries extractives</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>31001</code>
-            <name>
-                <narrative>Global Development Network</narrative>
-                <narrative xml:lang="fr">Réseau de développement mondial</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>31002</code>
-            <name>
-                <narrative>Global Knowledge Partnership</narrative>
-                <narrative xml:lang="fr">Alliance mondiale pour le savoir</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>21017</code>
-            <name>
-                <narrative>International Centre for Trade and Sustainable Development</narrative>
-                <narrative xml:lang="fr">Centre international de commerce et de développement durable</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>31003</code>
-            <name>
-                <narrative>International Land Coalition</narrative>
-                <narrative xml:lang="fr">Coalition internationale pour l'accès à la terre</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>31005</code>
-            <name>
-                <narrative>Parliamentary Network on the World Bank</narrative>
-                <narrative xml:lang="fr">Réseau parlementaire sur la Banque mondaile</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>40000</code>
-            <name>
-                <narrative>MULTILATERAL ORGANISATIONS</narrative>
-                <narrative xml:lang="fr">ORGANISATIONS MULTILATÉRALES</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41000</code>
-            <name>
-                <narrative>United Nations agency, fund or commission (UN)</narrative>
-                <narrative xml:lang="fr">Agence, fonds ou commission des Nations unies (NU)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41147</code>
-            <name>
-                <narrative>Central Emergency Response Fund</narrative>
-                <narrative xml:lang="fr">Fonds central pour les interventions d'urgence</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41101</code>
-            <name>
-                <narrative>Convention to Combat Desertification</narrative>
-                <narrative xml:lang="fr">Convention sur la lutte contre la désertification</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41102</code>
-            <name>
-                <narrative>Desert Locust Control Organisation for Eastern Africa</narrative>
-                <narrative xml:lang="fr">Organisation de lutte contre le criquet pèlerin dans l'Est Africain</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41106</code>
-            <name>
-                <narrative>Economic and Social Commission for Asia and the Pacific</narrative>
-                <narrative xml:lang="fr">Commission économique et sociale pour l'Asie et le Pacifique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41105</code>
-            <name>
-                <narrative>Economic and Social Commission for Western Asia</narrative>
-                <narrative xml:lang="fr">Commission économique et sociale pour l'Asie occidentale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41103</code>
-            <name>
-                <narrative>Economic Commission for Africa</narrative>
-                <narrative xml:lang="fr">Commission économique pour l'Afrique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41104</code>
-            <name>
-                <narrative>Economic Commission for Latin America and the Caribbean</narrative>
-                <narrative xml:lang="fr">Commission économique pour l'Amérique latine et les Caraïbes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41301</code>
-            <name>
-                <narrative>Food and Agricultural Organisation</narrative>
-                <narrative xml:lang="fr">Organisation des Nations Unies pour l'alimentation et l'agriculture</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41318</code>
-            <name>
-                <narrative>Global Mechanism</narrative>
-                <narrative xml:lang="fr">Mécanisme mondial</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41317</code>
-            <name>
-                <narrative>Green Climate Fund</narrative>
-                <narrative xml:lang="fr">Fonds vert pour le climat</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41312</code>
-            <name>
-                <narrative>International Atomic Energy Agency - assessed contributions</narrative>
-                <narrative xml:lang="fr">Agence internationale de l'énergie atomique - contributions obligatoires</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41107</code>
-            <name>
-                <narrative>International Atomic Energy Agency (Contributions to Technical Cooperation Fund Only)</narrative>
-                <narrative xml:lang="fr">Agence internationale de l'énergie atomique (Contributions au Fonds de Coopération Technique uniquement)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41108</code>
-            <name>
-                <narrative>International Fund for Agricultural Development</narrative>
-                <narrative xml:lang="fr">Fonds international de développement agricole</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41302</code>
-            <name>
-                <narrative>International Labour Organisation - Assessed Contributions</narrative>
-                <narrative xml:lang="fr">Organisation internationale du travail - contributions obligatoires</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41144</code>
-            <name>
-                <narrative>International Labour Organisation - Regular Budget Supplementary Account</narrative>
-                <narrative xml:lang="fr">Organisation internationale du Travail - Compte supplémentaire du budget ordinaire</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41145</code>
-            <name>
-                <narrative>International Maritime Organization - Technical Co-operation Fund</narrative>
-                <narrative xml:lang="fr">Organisation maritime internationale - Programme intégré de coopération technique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41303</code>
-            <name>
-                <narrative>International Telecommunications Union</narrative>
-                <narrative xml:lang="fr">Union internationale des télécommunications</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41110</code>
-            <name>
-                <narrative>Joint United Nations Programme on HIV/AIDS</narrative>
-                <narrative xml:lang="fr">Programme commun des Nations Unies sur le VIH/SIDA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41305</code>
-            <name>
-                <narrative>United Nations</narrative>
-                <narrative xml:lang="fr">Organisation des Nations Unies</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41111</code>
-            <name>
-                <narrative>United Nations Capital Development Fund</narrative>
-                <narrative xml:lang="fr">Fonds d’équipement des Nations Unies</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41122</code>
-            <name>
-                <narrative>United Nations Children’s Fund</narrative>
-                <narrative xml:lang="fr">Fonds des Nations Unies pour l'enfance</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41112</code>
-            <name>
-                <narrative>United Nations Conference on Trade and Development</narrative>
-                <narrative xml:lang="fr">Conférence des Nations Unies sur le commerce et le développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41142</code>
-            <name>
-                <narrative>United Nations Democracy Fund</narrative>
-                <narrative xml:lang="fr">Fonds des Nations Unies pour la démocratie</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41310</code>
-            <name>
-                <narrative>United Nations Department of Peacekeeping Operations [only MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, UNAMID, UNIFIL, UNISFA, UNMIK, UNMIL, UNMISS, UNOCI]. Report contributions mission by mission in CRS++.</narrative>
-                <narrative xml:lang="fr">Département des opérations de maintien de la paix des Nations unies [seulement MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, MINUAD, FINUL, FISNUA, MINUK, MINUL, UNMISS, ONUCI]. Notifier les contributions mission par mission au format SNPC++.</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41148</code>
-            <name>
-                <narrative>United Nations Department of Political Affairs, Trust Fund in Support of Political Affairs</narrative>
-                <narrative xml:lang="fr">Département des affaires politiques des Nations unies, fonds fiduciaire de soutien aux affaires politiques</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41114</code>
-            <name>
-                <narrative>United Nations Development Programme</narrative>
-                <narrative xml:lang="fr">Programme des Nations Unies pour le développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41314</code>
-            <name>
-                <narrative>United Nations Economic Commission for Europe (extrabudgetary contributions only)</narrative>
-                <narrative xml:lang="fr">Commission économique des Nations unies pour l'Europe (contributions extrabudgétaires uniquement)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41304</code>
-            <name>
-                <narrative>United Nations Educational, Scientific and Cultural Organisation</narrative>
-                <narrative xml:lang="fr">Organisation des Nations Unies pour l’éducation, la science et la culture</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41146</code>
-            <name>
-                <narrative>United Nations Entity for Gender Equality and the Empowerment of Women</narrative>
-                <narrative xml:lang="fr">Entité des Nations Unies pour l'égalité des sexes et l'autonomisation de la femme</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41116</code>
-            <name>
-                <narrative>United Nations Environment Programme</narrative>
-                <narrative xml:lang="fr">Programme des Nations Unies pour l'environnement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41316</code>
-            <name>
-                <narrative>United Nations Framework Convention on Climate Change</narrative>
-                <narrative xml:lang="fr">Convention-cadre des Nations unies sur les changements climatiques</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41313</code>
-            <name>
-                <narrative>United Nations High Commissioner for Human Rights (extrabudgetary contributions only)</narrative>
-                <narrative xml:lang="fr">Haut-Commissariat des Nations unies aux droits de l'homme (contributions extrabudgétaires uniquement)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41120</code>
-            <name>
-                <narrative>United Nations Human Settlement Programme</narrative>
-                <narrative xml:lang="fr">Programme des Nations Unies pour les établissements humains</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41123</code>
-            <name>
-                <narrative>United Nations Industrial Development Organisation</narrative>
-                <narrative xml:lang="fr">Organisation des Nations Unies pour le développement industriel</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41125</code>
-            <name>
-                <narrative>United Nations Institute for Training and Research</narrative>
-                <narrative xml:lang="fr">Institut des Nations Unies pour la formation et la recherche</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41315</code>
-            <name>
-                <narrative>United Nations International Strategy for Disaster Reduction</narrative>
-                <narrative xml:lang="fr">Stratégie internationale des Nations Unies pour la prévention de catastrophes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41126</code>
-            <name>
-                <narrative>United Nations Mine Action Service</narrative>
-                <narrative xml:lang="fr">Service de l'action antimines des Nations Unies</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41502</code>
-            <name>
-                <narrative>United Nations Office for Project Services</narrative>
-                <narrative xml:lang="fr">Le Bureau des Nations Unies pour les services d'appui aux projets</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41127</code>
-            <name>
-                <narrative>United Nations Office of Co-ordination of Humanitarian Affairs</narrative>
-                <narrative xml:lang="fr">Bureau des Nations Unies pour la coordination de l'assistance humanitaire</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41121</code>
-            <name>
-                <narrative>United Nations Office of the United Nations High Commissioner for Refugees</narrative>
-                <narrative xml:lang="fr">Haut Commissariat des Nations Unies pour les réfugiés</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41128</code>
-            <name>
-                <narrative>United Nations Office on Drugs and Crime</narrative>
-                <narrative xml:lang="fr">Office des Nations Unies contre la drogue et le crime</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41311</code>
-            <name>
-                <narrative>United Nations Peacebuilding Fund (Window One:  Flexible Contributions Only)</narrative>
-                <narrative xml:lang="fr">Fonds des Nations Unies pour la consolidation de la paix (Guichet un:  contributions sans conditions)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41141</code>
-            <name>
-                <narrative>United Nations Peacebuilding Fund (Window Two:  Restricted Contributions Only)</narrative>
-                <narrative xml:lang="fr">Fonds des Nations Unies pour la consolidation de la paix (Guichet deux:  contributions réservées)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41119</code>
-            <name>
-                <narrative>United Nations Population Fund</narrative>
-                <narrative xml:lang="fr">Fonds des Nations Unies pour la population</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41501</code>
-            <name>
-                <narrative>United Nations Reducing Emissions from Deforestation and Forest Degradation</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41130</code>
-            <name>
-                <narrative>United Nations Relief and Works Agency for Palestine Refugees in the Near East</narrative>
-                <narrative xml:lang="fr">Office de secours et de travaux des Nations Unies pour les réfugiés de Palestine dans le Proche-Orient</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41129</code>
-            <name>
-                <narrative>United Nations Research Institute for Social Development</narrative>
-                <narrative xml:lang="fr">Institut de recherche des Nations Unies pour le développement social</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41133</code>
-            <name>
-                <narrative>United Nations Special Initiative on Africa</narrative>
-                <narrative xml:lang="fr">Initiative spéciale des Nations Unies pour l'Afrique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41131</code>
-            <name>
-                <narrative>United Nations System Staff College</narrative>
-                <narrative xml:lang="fr">Ecole des cadres du système des Nations Unies</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41132</code>
-            <name>
-                <narrative>United Nations System Standing Committee on Nutrition</narrative>
-                <narrative xml:lang="fr">Comité permanent de la nutrition du système des Nations Unies</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41134</code>
-            <name>
-                <narrative>United Nations University (including Endowment Fund)</narrative>
-                <narrative xml:lang="fr">Université des Nations Unies (y compris le Fonds de dotation)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41137</code>
-            <name>
-                <narrative>United Nations Voluntary Fund for Technical Co-operation in the Field of Human Rights</narrative>
-                <narrative xml:lang="fr">Fonds de contributions volontaires des Nations Unies pour la coopération technique dans le domaine des droits de l'homme</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41138</code>
-            <name>
-                <narrative>United Nations Voluntary Fund for Victims of Torture</narrative>
-                <narrative xml:lang="fr">Fonds de contributions volontaires des Nations Unies pour les victimes de la torture</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41136</code>
-            <name>
-                <narrative>United Nations Voluntary Fund on Disability</narrative>
-                <narrative xml:lang="fr">Fonds de contributions voluntaires des Nations Unies pour les handicapés</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41135</code>
-            <name>
-                <narrative>United Nations Volunteers</narrative>
-                <narrative xml:lang="fr">Programme des volontaires des Nations Unies</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41306</code>
-            <name>
-                <narrative>Universal Postal Union</narrative>
-                <narrative xml:lang="fr">Union postale universelle</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2017-08-08">
-            <code>41503</code>
-            <name>
-                <narrative>UN-led Country-based Pooled Funds</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41140</code>
-            <name>
-                <narrative>World Food Programme</narrative>
-                <narrative xml:lang="fr">Programme alimentaire mondial</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41307</code>
-            <name>
-                <narrative>World Health Organisation - assessed contributions</narrative>
-                <narrative xml:lang="fr">Organisation mondiale de la santé - contributions obligatoires</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41143</code>
-            <name>
-                <narrative>World Health Organisation - core voluntary contributions account</narrative>
-                <narrative xml:lang="fr">Organisation mondiale de la santé - compte de contributions volontaires sans objet désigné</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41308</code>
-            <name>
-                <narrative>World Intellectual Property Organisation</narrative>
-                <narrative xml:lang="fr">Organisation mondiale de la propriété intellectuelle</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>41309</code>
-            <name>
-                <narrative>World Meteorological Organisation</narrative>
-                <narrative xml:lang="fr">Organisation météorologique mondiale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2017-08-08">
-            <code>41319</code>
-            <name>
-                <narrative>World Tourism Organization</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>42000</code>
-            <name>
-                <narrative>European Union Institution (EU)</narrative>
-                <narrative xml:lang="fr">Institution de l’Union européenne (UE)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>42001</code>
-            <name>
-                <narrative>European Commission - Development Share of Budget</narrative>
-                <narrative xml:lang="fr">Commission européenne - partie du budget affectée au développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>42003</code>
-            <name>
-                <narrative>European Commission - European Development Fund</narrative>
-                <narrative xml:lang="fr">Commission européenne - Fonds européen de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>42004</code>
-            <name>
-                <narrative>European Investment Bank</narrative>
-                <narrative xml:lang="fr">Banque européenne d'investissement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>43000</code>
-            <name>
-                <narrative>International Monetary Fund (IMF)</narrative>
-                <narrative xml:lang="fr">Fonds monétaire international (FMI)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>43005</code>
-            <name>
-                <narrative>International Monetary Fund - Post-Catastrophe Debt Relief Trust</narrative>
-                <narrative xml:lang="fr">Fonds monétaire international  - Fonds fiduciaire pour l'allégement de la dette après une catastrophe</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>43002</code>
-            <name>
-                <narrative>International Monetary Fund - Poverty Reduction and Growth - Heavily Indebted Poor Countries Debt Relief Initiative Trust Fund [includes HIPC, Extended Credit Facility (ECF), and ECF-HIPC sub-accounts]</narrative>
-                <narrative xml:lang="fr">Fonds monétaire international – Réduction de la pauvreté et croissance – Initiative d’allègement de la dette en faveur des pays pauvres très endettés [y compris Initiative PPTE, Facilité élargie de crédit (FEC) et sous-comptes (FEC-PPTE)]</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>43004</code>
-            <name>
-                <narrative>International Monetary Fund - Poverty Reduction and Growth - Multilateral Debt Relief Initiative Trust</narrative>
-                <narrative xml:lang="fr">Fonds monétaire international – Facilité pour la réduction de la pauvreté et pour la croissance – Initiative d’allègement de la dette multilatérale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>43001</code>
-            <name>
-                <narrative>International Monetary Fund - Poverty Reduction and Growth Trust</narrative>
-                <narrative xml:lang="fr">Fonds monétaire international – Facilité pour la réduction de la pauvreté et pour la croissance</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>43003</code>
-            <name>
-                <narrative>International Monetary Fund - Subsidization of Emergency Post Conflict Assistance/Emergency Assistance for Natural Disasters for PRGT-eligible members</narrative>
-                <narrative xml:lang="fr">Fonds monétaire international – Aide d’urgence après un conflit (EPCA) et aide d’urgence à la suite de catastrophes naturelles (ENDA) pour les membres pouvant bénéficier de la FRPC</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
-            <code>43006</code>
-            <name>
-                <narrative>Catastrophe Containment and Relief Trust</narrative>
-                <narrative xml:lang="fr">Fonds fiduciaire d’assistance et de riposte aux catastrophes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>44000</code>
-            <name>
-                <narrative>World Bank Group (WB)</narrative>
-                <narrative xml:lang="fr">Groupe de la Banque mondiale (BM)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>44006</code>
-            <name>
-                <narrative>Advance Market Commitments</narrative>
-                <narrative xml:lang="fr">Garanties de marché</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>44001</code>
-            <name>
-                <narrative>International Bank for Reconstruction and Development</narrative>
-                <narrative xml:lang="fr">Banque internationale pour la reconstruction et le développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>44002</code>
-            <name>
-                <narrative>International Development Association</narrative>
-                <narrative xml:lang="fr">Association internationale de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>44003</code>
-            <name>
-                <narrative>International Development Association - Heavily Indebted Poor Countries Debt Initiative Trust Fund</narrative>
-                <narrative xml:lang="fr">Association internationale de développement - Fonds fiduciaire de l'IDA en faveur des pays pauvres très endettés</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>44007</code>
-            <name>
-                <narrative>International Development Association - Multilateral Debt Relief Initiative</narrative>
-                <narrative xml:lang="fr">Association internationale de développement - Initiative d’allégement de la dette multilatérale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>44004</code>
-            <name>
-                <narrative>International Finance Corporation</narrative>
-                <narrative xml:lang="fr">Société financière internationale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>44005</code>
-            <name>
-                <narrative>Multilateral Investment Guarantee Agency</narrative>
-                <narrative xml:lang="fr">Agence multilatérale de garantie des investissements</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>45000</code>
-            <name>
-                <narrative>World Trade Organisation</narrative>
-                <narrative xml:lang="fr">Organisation mondiale du commerce (OMC)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>45002</code>
-            <name>
-                <narrative>World Trade Organisation - Advisory Centre on WTO Law</narrative>
-                <narrative xml:lang="fr">Centre consultatif sur la législation de l'Organisation mondiale du commerce</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>45003</code>
-            <name>
-                <narrative>World Trade Organisation - Doha Development Agenda Global Trust Fund</narrative>
-                <narrative xml:lang="fr">Organisation mondiale du commerce - Fonds global d'affectation spéciale pour le Programme de Doha pour le développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>45001</code>
-            <name>
-                <narrative>World Trade Organisation - International Trade Centre</narrative>
-                <narrative xml:lang="fr">Centre du commerce international de l'Organisation mondiale du commerce</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46000</code>
-            <name>
-                <narrative>Regional Development Bank</narrative>
-                <narrative xml:lang="fr">Banque régionale de développement (BRD)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46002</code>
-            <name>
-                <narrative>African Development Bank</narrative>
-                <narrative xml:lang="fr">Banque africaine de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46003</code>
-            <name>
-                <narrative>African Development Fund</narrative>
-                <narrative xml:lang="fr">Fonds africain de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46022</code>
-            <name>
-                <narrative>African Export Import Bank</narrative>
-                <narrative xml:lang="fr">Banque Africaine d'Import-Export</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46008</code>
-            <name>
-                <narrative>Andean Development Corporation</narrative>
-                <narrative xml:lang="fr">Société andine de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46004</code>
-            <name>
-                <narrative>Asian Development Bank</narrative>
-                <narrative xml:lang="fr">Banque asiatique de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46005</code>
-            <name>
-                <narrative>Asian Development Fund</narrative>
-                <narrative xml:lang="fr">Fonds asiatique de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2017-08-08">
-            <code>46026</code>
-            <name>
-                <narrative>Asian Infrastructure Investment Bank</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46006</code>
-            <name>
-                <narrative>Black Sea Trade and Development Bank</narrative>
-                <narrative xml:lang="fr">Black Sea Trade and Development Bank</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46009</code>
-            <name>
-                <narrative>Caribbean Development Bank</narrative>
-                <narrative xml:lang="fr">Banque de développement des Caraïbes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46020</code>
-            <name>
-                <narrative>Central African States Development Bank</narrative>
-                <narrative xml:lang="fr">Banque de développement des États de l'Afrique Centrale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46007</code>
-            <name>
-                <narrative>Central American Bank for Economic Integration</narrative>
-                <narrative xml:lang="fr">Banque centroaméricaine d'intégration économique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46024</code>
-            <name>
-                <narrative>Council of Europe Development Bank</narrative>
-                <narrative xml:lang="fr">Banque de Développement du Conseil de l'Europe</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46023</code>
-            <name>
-                <narrative>Eastern and Southern African Trade and Development Bank</narrative>
-                <narrative xml:lang="fr">Banque de l’Afrique de l’Est et de l’Afrique Australe pour le Commerce et le Développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46015</code>
-            <name>
-                <narrative>European Bank for Reconstruction and Development</narrative>
-                <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46018</code>
-            <name>
-                <narrative>European Bank for Reconstruction and Development - Early Transition Countries Fund</narrative>
-                <narrative xml:lang="fr">Banque européenne de reconstruction et de développement - Initiative en faveur des pays en transition précoce</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46017</code>
-            <name>
-                <narrative>European Bank for Reconstruction and Development – technical co-operation and special funds (all EBRD countries of operations)</narrative>
-                <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement - coopération technique et fonds spéciaux (tous pays)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46016</code>
-            <name>
-                <narrative>European Bank for Reconstruction and Development – technical co-operation and special funds (ODA-eligible countries only)</narrative>
-                <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement - coopération technique et fonds spéciaux (pays éligibles à l'APD)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46019</code>
-            <name>
-                <narrative>European Bank for Reconstruction and Development - Western Balkans Joint Trust Fund</narrative>
-                <narrative xml:lang="fr">Banque européenne de reconstruction et de développement - Fonds spécial pour les Balkans occidentaux</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46013</code>
-            <name>
-                <narrative>Inter-American Development Bank, Fund for Special Operations</narrative>
-                <narrative xml:lang="fr">Banque interaméricaine de développement, Fonds opérations spécial</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46012</code>
-            <name>
-                <narrative>Inter-American Development Bank, Inter-American Investment Corporation and Multilateral Investment Fund</narrative>
-                <narrative xml:lang="fr">Banque interaméricaine de développement, Société interaméricaine d'investissements, Fonds multilatéral d'investissements</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46025</code>
-            <name>
-                <narrative>Islamic Development Bank</narrative>
-                <narrative xml:lang="fr">Banque Islamique de Développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>46021</code>
-            <name>
-                <narrative>West African Development Bank</narrative>
-                <narrative xml:lang="fr">Banque ouest-africaine de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47000</code>
-            <name>
-                <narrative>Other multilateral institution</narrative>
-                <narrative xml:lang="fr">Autre institution multilatérale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47111</code>
-            <name>
-                <narrative>Adaptation Fund</narrative>
-                <narrative xml:lang="fr">Fonds pour l’adaptation</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47009</code>
-            <name>
-                <narrative>African and Malagasy Council for Higher Education</narrative>
-                <narrative xml:lang="fr">Conseil africain et malgache pour l'enseignement supérieur</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47001</code>
-            <name>
-                <narrative>African Capacity Building Foundation</narrative>
-                <narrative xml:lang="fr">Fondation pour le renforcement des capacités en Afrique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47137</code>
-            <name>
-                <narrative>African Risk Capacity Group</narrative>
-                <narrative xml:lang="fr">Mutuelle panafricaine de gestion des risques</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47141</code>
-            <name>
-                <narrative>African Tax Administration Forum</narrative>
-                <narrative xml:lang="fr">Forum sur l’Administration Fiscale Africaine</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47005</code>
-            <name>
-                <narrative>African Union (excluding peacekeeping facilities)</narrative>
-                <narrative xml:lang="fr">Union Africaine (à l'exclusion de la Facilité de soutien à la paix)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
             <code>21002</code>
             <name>
                 <narrative>Agency for International Trade Information and Co-operation</narrative>
                 <narrative xml:lang="fr">Agence de coopération et d'information pour le commerce international</narrative>
             </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47002</code>
-            <name>
-                <narrative>Asian Productivity Organisation</narrative>
-                <narrative xml:lang="fr">Organisation asiatique de productivité</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47109</code>
-            <name>
-                <narrative>Asia-Pacific Economic Cooperation Support Fund (except contributions tied to counter-terrorism activities)</narrative>
-                <narrative xml:lang="fr">Fonds de soutien de la coopération économique Asie-Pacifique (hors lutte contre le terrorisme)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47068</code>
-            <name>
-                <narrative>Asia-Pacific Fishery Commission</narrative>
-                <narrative xml:lang="fr">Commission Asie-Pacifique des pêches</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47003</code>
-            <name>
-                <narrative>Association of South East Asian Nations: Economic Co-operation</narrative>
-                <narrative xml:lang="fr">Association des nations de l'Asie du Sud-Est - coopération économique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47011</code>
-            <name>
-                <narrative>Caribbean Community Secretariat</narrative>
-                <narrative xml:lang="fr">Secrétariat de la Communauté des Caraïbes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47012</code>
-            <name>
-                <narrative>Caribbean Epidemiology Centre</narrative>
-                <narrative xml:lang="fr">Centre épidémiologique des Caraïbes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2017-08-08">
-            <code>47145</code>
-            <name>
-                <narrative>Center of Excellence in Finance</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47112</code>
-            <name>
-                <narrative>Central European Initiative - Special Fund for Climate and Environmental Protection</narrative>
-                <narrative xml:lang="fr">Initiative de l’Europe centrale -  Fonds Spécial pour la protection climatique et environnementale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47015</code>
-            <name>
-                <narrative>CGIAR Fund</narrative>
-                <narrative xml:lang="fr">CGIAR Fund</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47134</code>
-            <name>
-                <narrative>Clean Technology Fund</narrative>
-                <narrative xml:lang="fr">Fonds pour les technologies propres</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47027</code>
-            <name>
-                <narrative>Colombo Plan</narrative>
-                <narrative xml:lang="fr">Plan de Colombo</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47105</code>
-            <name>
-                <narrative>Common Fund for Commodities</narrative>
-                <narrative xml:lang="fr">Fonds commun pour les produits de base</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47013</code>
-            <name>
-                <narrative>Commonwealth Foundation</narrative>
-                <narrative xml:lang="fr">Fondation du Commonwealth</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47025</code>
-            <name>
-                <narrative>Commonwealth of Learning</narrative>
-                <narrative xml:lang="fr">Commonwealth of Learning</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47132</code>
-            <name>
-                <narrative>Commonwealth Secretariat (ODA-eligible contributions only)</narrative>
-                <narrative xml:lang="fr">Secrétariat du Commonwealth (seulement les contributions éligibles à l'APD)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47026</code>
-            <name>
-                <narrative>Community of Portuguese Speaking Countries</narrative>
-                <narrative xml:lang="fr">Communauté des pays de langue portugaise</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47022</code>
-            <name>
-                <narrative>Convention on International Trade in Endangered Species of Wild Flora and Fauna</narrative>
-                <narrative xml:lang="fr">Convention sur le commerce international des espèces de faune et de flore sauvages menacées d'extinction</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47138</code>
-            <name>
-                <narrative>Council of Europe</narrative>
-                <narrative xml:lang="fr">Conseil de l’Europe</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47037</code>
-            <name>
-                <narrative>Eastern-Regional Organisation of Public Administration</narrative>
-                <narrative xml:lang="fr">Organisation régionale de l'Orient pour l'administration publique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47113</code>
-            <name>
-                <narrative>Economic and Monetary Community of Central Africa</narrative>
-                <narrative xml:lang="fr">Communauté économique et monétaire de l’Afrique Centrale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47034</code>
-            <name>
-                <narrative>Economic Community of West African States</narrative>
-                <narrative xml:lang="fr">Communauté économique des Etats de l’Afrique de l’Ouest</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47036</code>
-            <name>
-                <narrative>European and Mediterranean Plant Protection Organisation</narrative>
-                <narrative xml:lang="fr">Organisation Européenne et Méditerranéenne pour la Protection des Plantes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47504</code>
-            <name>
-                <narrative>Forest Carbon Partnership Facility</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47040</code>
-            <name>
-                <narrative>Forum Fisheries Agency</narrative>
-                <narrative xml:lang="fr">Agence des pêches</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47106</code>
-            <name>
-                <narrative>Geneva Centre for the Democratic Control of Armed Forces</narrative>
-                <narrative xml:lang="fr">Centre de contrôle démocratique des forces armées - Genève</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47123</code>
-            <name>
-                <narrative>Geneva International Centre for Humanitarian Demining</narrative>
-                <narrative xml:lang="fr">Centre International de Déminage Humanitaire Genève</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47503</code>
-            <name>
-                <narrative>Global Agriculture and Food Security Program</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47122</code>
-            <name>
-                <narrative>Global Alliance for Vaccines and Immunization</narrative>
-                <narrative xml:lang="fr">Alliance mondiale pour la vaccination et l’immunisation</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47129</code>
-            <name>
-                <narrative>Global Environment Facility - Least Developed Countries Fund</narrative>
-                <narrative xml:lang="fr">FEM Fonds pour les pays les moins avancés</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47130</code>
-            <name>
-                <narrative>Global Environment Facility - Special Climate Change Fund</narrative>
-                <narrative xml:lang="fr">FEM Fonds spécial pour les changements climatiques</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47044</code>
-            <name>
-                <narrative>Global Environment Facility Trust Fund</narrative>
-                <narrative xml:lang="fr">Fonds pour l'environnement mondial - fonds fiduciaire</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47502</code>
-            <name>
-                <narrative>Global Fund for Disaster Risk Reduction</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47045</code>
-            <name>
-                <narrative>Global Fund to Fight AIDS, Tuberculosis and Malaria</narrative>
-                <narrative xml:lang="fr">Fonds mondial de lutte contre le SIDA, la tuberculose et la paludisme</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47136</code>
-            <name>
-                <narrative>Global Green Growth Institute</narrative>
-                <narrative xml:lang="fr">Institut mondial de la croissance verte</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47501</code>
-            <name>
-                <narrative>Global Partnership for Education</narrative>
-                <narrative xml:lang="fr">Partenariat Mondial pour l'Education</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47116</code>
-            <name>
-                <narrative>Integrated Framework for Trade-Related Technical Assistance to Least Developed Countries</narrative>
-                <narrative xml:lang="fr">Cadre intégré pour l'assistance technique liée au commerce en faveur des pays les moins avancés</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47061</code>
-            <name>
-                <narrative>Inter-American Institute for Co-operation on Agriculture</narrative>
-                <narrative xml:lang="fr">Institut interaméricain de coopération pour l’agriculture</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47065</code>
-            <name>
-                <narrative>Intergovernmental Oceanographic Commission</narrative>
-                <narrative xml:lang="fr">Commission océanographique intergouvernementale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47067</code>
-            <name>
-                <narrative>Intergovernmental Panel on Climate Change</narrative>
-                <narrative xml:lang="fr">Groupe d’experts intergouvernemental sur l’évolution du climat</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47019</code>
-            <name>
-                <narrative>International Centre for Advanced Mediterranean Agronomic Studies</narrative>
-                <narrative xml:lang="fr">Centre international de hautes études agronomique méditerranéennes</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47050</code>
-            <name>
-                <narrative>International Cotton Advisory Committee</narrative>
-                <narrative xml:lang="fr">Comité consultatif international du coton</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47059</code>
-            <name>
-                <narrative>International Development Law Organisation</narrative>
-                <narrative xml:lang="fr">Organisation internationale de droit du développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>30010</code>
-            <name>
-                <narrative>International drug purchase facility</narrative>
-                <narrative xml:lang="fr">Facilité internationale d'achat de médicaments</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47107</code>
-            <name>
-                <narrative>International Finance Facility for Immunisation</narrative>
-                <narrative xml:lang="fr">Facilité internationale de financement pour la vaccination</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47058</code>
-            <name>
-                <narrative>International Institute for Democracy and Electoral Assistance</narrative>
-                <narrative xml:lang="fr">International Institute for Democracy and Electoral Assistance</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47064</code>
-            <name>
-                <narrative>International Network for Bamboo and Rattan</narrative>
-                <narrative xml:lang="fr">Réseau International sur le bambou et le rotin</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47066</code>
-            <name>
-                <narrative>International Organisation for Migration</narrative>
-                <narrative xml:lang="fr">Organisation internationale des migrations</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47046</code>
-            <name>
-                <narrative>International Organisation of the Francophonie</narrative>
-                <narrative xml:lang="fr">Organisation internationale de la Francophonie</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47073</code>
-            <name>
-                <narrative>International Tropical Timber Organisation</narrative>
-                <narrative xml:lang="fr">Organisation Internationale des Bois Tropicaux</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47074</code>
-            <name>
-                <narrative>International Vaccine Institute</narrative>
-                <narrative xml:lang="fr">Institut international de vaccins</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47076</code>
-            <name>
-                <narrative>Justice Studies Centre of the Americas</narrative>
-                <narrative xml:lang="fr">Centre d’études sur la justice dans les Amériques</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47127</code>
-            <name>
-                <narrative>Latin-American Energy Organisation</narrative>
-                <narrative xml:lang="fr">Organisation latino-américaine de l'énergie</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47077</code>
-            <name>
-                <narrative>Mekong River Commission</narrative>
-                <narrative xml:lang="fr">Commission du Mékong</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47078</code>
-            <name>
-                <narrative>Multilateral Fund for the Implementation of the Montreal Protocol</narrative>
-                <narrative xml:lang="fr">Fonds multilatéral pour l’application du Protocole de Montréal</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47117</code>
-            <name>
-                <narrative>New Partnership for Africa's Development</narrative>
-                <narrative xml:lang="fr">Nouveau Partenariat pour le développement de l’Afrique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47128</code>
-            <name>
-                <narrative>Nordic Development Fund</narrative>
-                <narrative xml:lang="fr">Nordic Development Fund</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47081</code>
-            <name>
-                <narrative>OECD Development Centre</narrative>
-                <narrative xml:lang="fr">OCDE Centre de développement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47142</code>
-            <name>
-                <narrative>OPEC Fund for International Development</narrative>
-                <narrative xml:lang="fr">Le Fonds OPEP pour le développement international</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47080</code>
-            <name>
-                <narrative>Organisation for Economic Co-operation and Development (Contributions to special funds for Technical Co-operation Activities Only)</narrative>
-                <narrative xml:lang="fr">Organisation de Coopération et de développement économiques (contributions aux fonds spéciaux pour les activités de coopération technique uniquement)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47079</code>
-            <name>
-                <narrative>Organisation of American States</narrative>
-                <narrative xml:lang="fr">Organisation des États américains</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47082</code>
-            <name>
-                <narrative>Organisation of Eastern Caribbean States</narrative>
-                <narrative xml:lang="fr">Organisation des États des Caraïbes orientales</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47140</code>
-            <name>
-                <narrative>Organisation of Ibero-American States for Education, Science and Culture</narrative>
-                <narrative xml:lang="fr">Organización de Estados Iberoamericanos</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47110</code>
-            <name>
-                <narrative>Organisation of the Black Sea Economic Cooperation</narrative>
-                <narrative xml:lang="fr">Organisation de coopération économique de la mer Noire</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47131</code>
-            <name>
-                <narrative>Organization for Security and Co-operation in Europe</narrative>
-                <narrative xml:lang="fr">Organisation pour la sécurité et la oopération en Europe</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47087</code>
-            <name>
-                <narrative>Pacific Islands Forum Secretariat</narrative>
-                <narrative xml:lang="fr">Secrétariat du Forum des Iles du Pacifique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47097</code>
-            <name>
-                <narrative>Pacific Regional Environment Programme</narrative>
-                <narrative xml:lang="fr">Programme régional océanien de l’environnement</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47083</code>
-            <name>
-                <narrative>Pan-American Health Organisation</narrative>
-                <narrative xml:lang="fr">Organisation panaméricaine de la santé</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47084</code>
-            <name>
-                <narrative>Pan-American Institute of Geography and History</narrative>
-                <narrative xml:lang="fr">Institut panaméricain de géographie et d’histoire</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47086</code>
-            <name>
-                <narrative>Private Infrastructure Development Group</narrative>
-                <narrative xml:lang="fr">Private Infrastructure Development Group</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47118</code>
-            <name>
-                <narrative>Regional Organisation for the Strengthening of Supreme Audit Institutions of Francophone Sub-Saharan Countries</narrative>
-                <narrative xml:lang="fr">Conseil Régional de Formation des Institutions Supérieures de Contrôle des Finances Publiques d’Afrique Francophone Subsaharienne</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47119</code>
-            <name>
-                <narrative>Sahara and Sahel Observatory</narrative>
-                <narrative xml:lang="fr">Observatoire du Sahara et du Sahel</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47029</code>
-            <name>
-                <narrative>Sahel and West Africa Club</narrative>
-                <narrative xml:lang="fr">Club du Sahel et de l’Afrique de l’Ouest</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47096</code>
-            <name>
-                <narrative>Secretariat of the Pacific Community</narrative>
-                <narrative xml:lang="fr">Secrétariat Général de la Communauté du Pacifique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47120</code>
-            <name>
-                <narrative>South Asian Association for Regional Cooperation</narrative>
-                <narrative xml:lang="fr">Association de l'Asie du Sud pour la coopération régionale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47092</code>
-            <name>
-                <narrative>South East Asian Fisheries Development Centre</narrative>
-                <narrative xml:lang="fr">Centre de développement des pêches de l’Asie du Sud-Est</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47093</code>
-            <name>
-                <narrative>South East Asian Ministers of Education</narrative>
-                <narrative xml:lang="fr">Organisation des Ministres de l’éducation de l’Asie du Sud-Est</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47095</code>
-            <name>
-                <narrative>South Pacific Board for Educational Assessment</narrative>
-                <narrative xml:lang="fr">Conseil d’évaluation du Pacifique Sud pour l'éducation</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47089</code>
-            <name>
-                <narrative>Southern African Development Community</narrative>
-                <narrative xml:lang="fr">Communauté pour le développement de l’Afrique australe</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47135</code>
-            <name>
-                <narrative>Strategic Climate Fund</narrative>
-                <narrative xml:lang="fr">Fonds stratégique pour le climat</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47121</code>
-            <name>
-                <narrative>United Cities and Local Governments of Africa</narrative>
-                <narrative xml:lang="fr">Cités et gouvernements locaux unis d’Afrique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47098</code>
-            <name>
-                <narrative>Unrepresented Nations and Peoples’ Organisation</narrative>
-                <narrative xml:lang="fr">Organisation des peuples et des nations non représentés</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47100</code>
-            <name>
-                <narrative>West African Monetary Union</narrative>
-                <narrative xml:lang="fr">Union monétaire ouest-africaine</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47139</code>
-            <name>
-                <narrative>World Customs Organization Customs Co-operation Fund</narrative>
-                <narrative xml:lang="fr">Organisation Mondiale des Douanes Fonds de coopération douanière</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
-            <code>47143</code>
-            <name>
-                <narrative>Global Community Engagement and Resilience Fund</narrative>
-                <narrative xml:lang="fr">Fonds mondial pour l’engagement de la communauté et la résilience</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2016-07-06">
-            <code>47144</code>
-            <name>
-                <narrative>International Renewable Energy Agency</narrative>
-                <narrative xml:lang="fr">Agence internationale pour les energies renouvelables</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="withdrawn" activation-date="2015-12-07" withdrawal-date="2017-05-09">
-            <code>50000</code>
-            <name>
-                <narrative>Other</narrative>
-                <narrative xml:lang="fr">Autre</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>51000</code>
-            <name>
-                <narrative>University, college or other teaching institution, research institute or think‑tank</narrative>
-                <narrative xml:lang="fr">Université, institut d’éducation et autre institution d’enseignement, institut de recherche ou groupe de réflexion</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47101</code>
-            <name>
-                <narrative>Africa Rice Centre</narrative>
-                <narrative xml:lang="fr">Centre du riz pour l’Afrique</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47069</code>
-            <name>
-                <narrative>Bioversity International</narrative>
-                <narrative xml:lang="fr">Bioversity International</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47018</code>
-            <name>
-                <narrative>Centre for International Forestry Research</narrative>
-                <narrative xml:lang="fr">Centre de recherche forestière internationale</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21003</code>
+            <name>
+                <narrative>Latin American Council for Social Sciences</narrative>
+                <narrative xml:lang="fr">Conseil latino-américain des sciences sociales</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
             <code>21004</code>
             <name>
                 <narrative>Council for the Development of Economic and Social Research in Africa</narrative>
                 <narrative xml:lang="fr">Conseil pour le développement de la recherche en sciences sociales en Afrique</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47041</code>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21005</code>
             <name>
-                <narrative>Food and Fertilizer Technology Centre</narrative>
-                <narrative xml:lang="fr">Centre des techniques de l'alimentation et des engrais</narrative>
+                <narrative>Consumer Unity and Trust Society International</narrative>
+                <narrative xml:lang="fr">Consumer Unity and Trust Society International</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21006</code>
+            <name>
+                <narrative>Development Gateway Foundation</narrative>
+                <narrative xml:lang="fr">Development Gateway Foundation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21007</code>
+            <name>
+                <narrative>Environmental Liaison Centre International</narrative>
+                <narrative xml:lang="fr">Centre international de liaison pour l’environnement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21008</code>
+            <name>
+                <narrative>Eurostep</narrative>
+                <narrative xml:lang="fr">Eurostep</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
             <code>21009</code>
             <name>
                 <narrative>Forum for Agricultural Research in Africa</narrative>
                 <narrative xml:lang="fr">Forum pour la recherche agricole en Afrique</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47047</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21010</code>
             <name>
-                <narrative>International African Institute</narrative>
-                <narrative xml:lang="fr">Institut international africain</narrative>
+                <narrative>Forum for African Women Educationalists</narrative>
+                <narrative xml:lang="fr">Forum des éducatrices africaines</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47051</code>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>21011</code>
             <name>
-                <narrative>International Centre for Agricultural Research in Dry Areas</narrative>
-                <narrative xml:lang="fr">Centre international de recherche agricole dans les zones arides</narrative>
+                <narrative>Global Campaign for Education</narrative>
+                <narrative xml:lang="fr">Campagne mondiale pour l’éducation</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47055</code>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>21013</code>
             <name>
-                <narrative>International Centre for Development Oriented Research in Agriculture</narrative>
-                <narrative xml:lang="fr">Centre International pour la Recherche Agricole orientée vers le développement</narrative>
+                <narrative>Health Action International</narrative>
+                <narrative xml:lang="fr">Health Action International</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47053</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21014</code>
             <name>
-                <narrative>International Centre for Diarrhoeal Disease Research, Bangladesh</narrative>
-                <narrative xml:lang="fr">International Centre for Diarrhoeal Disease Research, Bangladesh</narrative>
+                <narrative>Human Rights Information and Documentation Systems</narrative>
+                <narrative xml:lang="fr">Systèmes d’Information et de Documentation sur les Droits de l’Homme</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47017</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21015</code>
             <name>
-                <narrative>International Centre for Tropical Agriculture</narrative>
-                <narrative xml:lang="fr">Centre international d'agriculture tropicale</narrative>
+                <narrative>International Catholic Rural Association</narrative>
+                <narrative xml:lang="fr">Association internationale rurale catholique</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47054</code>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>21016</code>
             <name>
-                <narrative>International Centre of Insect Physiology and Ecology</narrative>
-                <narrative xml:lang="fr">Centre international sur la physiologie et l’écologie des insectes</narrative>
+                <narrative>International Committee of the Red Cross</narrative>
+                <narrative xml:lang="fr">Comité international de la Croix-Rouge</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47057</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21017</code>
             <name>
-                <narrative>International Crop Research for Semi-Arid Tropics</narrative>
-                <narrative xml:lang="fr">Institut international de recherche sur les cultures des zones tropicales semi-arides</narrative>
+                <narrative>International Centre for Trade and Sustainable Development</narrative>
+                <narrative xml:lang="fr">Centre international de commerce et de développement durable</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>51001</code>
+        <codelist-item status="withdrawn" activation-date="2011-01-01" withdrawal-date="2011-12-31">
+            <code>21018</code>
             <name>
-                <narrative>International Food Policy Research Institute</narrative>
-                <narrative xml:lang="fr">Institut International de Recherche sur les Politiques Alimentaires</narrative>
+                <narrative>International Federation of Red Cross and Red Crescent Societies</narrative>
+                <narrative xml:lang="fr">Fédération internationale des Sociétés de la Croix-Rouge et du Croissant-Rouge</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21019</code>
+            <name>
+                <narrative>International Federation of Settlements and Neighbourhood Centres</narrative>
+                <narrative xml:lang="fr">Fédération internationale des centres sociaux et communautaires</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>21020</code>
+            <name>
+                <narrative>International HIV/AIDS Alliance</narrative>
+                <narrative xml:lang="fr">International HIV/AIDS Alliance</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
             <code>21021</code>
             <name>
                 <narrative>International Institute for Environment and Development</narrative>
                 <narrative xml:lang="fr">Institut international pour l’environnement et le développement</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21022</code>
+            <name>
+                <narrative>International Network for Alternative Financial Institutions</narrative>
+                <narrative xml:lang="fr">Réseau international d’institutions financières</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1999-01-01">
+            <code>21023</code>
+            <name>
+                <narrative>International Planned Parenthood Federation</narrative>
+                <narrative xml:lang="fr">Fédération internationale pour le planning familial</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21024</code>
+            <name>
+                <narrative>Inter Press Service, International Association</narrative>
+                <narrative xml:lang="fr">Inter Press Service, International Association</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21025</code>
+            <name>
+                <narrative>International Seismological Centre</narrative>
+                <narrative xml:lang="fr">Centre séismologique international</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21026</code>
+            <name>
+                <narrative>International Service for Human Rights</narrative>
+                <narrative xml:lang="fr">Service International pour les Droits de l’Homme</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21027</code>
+            <name>
+                <narrative>ITF Enhancing Human Security</narrative>
+                <narrative xml:lang="fr">ITF Améliorer la sécurité humaine</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21028</code>
+            <name>
+                <narrative>International University Exchange Fund - IUEF Stip. in Africa and Latin America</narrative>
+                <narrative xml:lang="fr">Fonds international d’échanges universitaires - Échanges intéressant l’Afrique et l’Amérique latine</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2002-01-01">
+            <code>21029</code>
+            <name>
+                <narrative>Doctors Without Borders</narrative>
+                <narrative xml:lang="fr">Médecins Sans Frontières</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21030</code>
+            <name>
+                <narrative>Pan African Institute for Development</narrative>
+                <narrative xml:lang="fr">Institut panafricain pour le développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21031</code>
+            <name>
+                <narrative>PANOS Institute</narrative>
+                <narrative xml:lang="fr">Institut PANOS</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>21032</code>
+            <name>
+                <narrative>Population Services International</narrative>
+                <narrative xml:lang="fr">Organisation internationale pour les services en matière de population</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21033</code>
+            <name>
+                <narrative>Transparency International</narrative>
+                <narrative xml:lang="fr">Transparency International</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2003-01-01" withdrawal-date="2003-12-31">
+            <code>21034</code>
+            <name>
+                <narrative>International Union Against Tuberculosis and Lung Disease</narrative>
+                <narrative xml:lang="fr">Union Internationale Contre la Tuberculose et les Maladies Respiratoires</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21035</code>
+            <name>
+                <narrative>World Organisation Against Torture</narrative>
+                <narrative xml:lang="fr">Organisation mondiale contre la torture</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21036</code>
+            <name>
+                <narrative>World University Service</narrative>
+                <narrative xml:lang="fr">Entraide universitaire mondiale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21037</code>
+            <name>
+                <narrative>Women's World Banking</narrative>
+                <narrative xml:lang="fr">Banque mondiale des femmes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21038</code>
+            <name>
+                <narrative>International Alert</narrative>
+                <narrative xml:lang="fr">International Alert</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
             <code>21039</code>
             <name>
                 <narrative>International Institute for Sustainable Development</narrative>
                 <narrative xml:lang="fr">Institut international de développement durable</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47062</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21040</code>
             <name>
-                <narrative>International Institute of Tropical Agriculture</narrative>
-                <narrative xml:lang="fr">Institut international d’agriculture tropicale</narrative>
+                <narrative>International Women's Tribune Centre</narrative>
+                <narrative xml:lang="fr">Centre de la tribune internationale de la femme</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47063</code>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21041</code>
             <name>
-                <narrative>International Livestock Research Institute</narrative>
-                <narrative xml:lang="fr">International Livestock Research Institute</narrative>
+                <narrative>Society for International Development</narrative>
+                <narrative xml:lang="fr">Société pour le développement international</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47020</code>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21042</code>
             <name>
-                <narrative>International Maize and Wheat Improvement Centre</narrative>
-                <narrative xml:lang="fr">Centre international d’amélioration du maïs et du blé</narrative>
+                <narrative>International Peacebuilding Alliance</narrative>
+                <narrative xml:lang="fr">Alliance internationale pour la consolidation de la paix</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47021</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21043</code>
             <name>
-                <narrative>International Potato Centre</narrative>
-                <narrative xml:lang="fr">Centre international de la pomme de terre</narrative>
+                <narrative>European Parliamentarians for Africa</narrative>
+                <narrative xml:lang="fr">Association des parlementaires d’Europe pour l’Afrique</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47070</code>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21044</code>
             <name>
-                <narrative>International Rice Research Institute</narrative>
-                <narrative xml:lang="fr">Institut international de recherche sur le riz</narrative>
+                <narrative>International Council for the Control of Iodine Deficiency Disorders</narrative>
+                <narrative xml:lang="fr">Conseil international pour la lutte contre les troubles dus à une carence en iode</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47071</code>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>21045</code>
             <name>
-                <narrative>International Seed Testing Association</narrative>
-                <narrative xml:lang="fr">Association internationale d’essais de semences</narrative>
+                <narrative>African Medical and Research Foundation</narrative>
+                <narrative xml:lang="fr">Fondation africaine pour la médecine et la recherche</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47075</code>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21046</code>
             <name>
-                <narrative>International Water Management Institute</narrative>
-                <narrative xml:lang="fr">Institut international de gestion des ressources en eau</narrative>
+                <narrative>Agency for Cooperation and Research in Development</narrative>
+                <narrative xml:lang="fr">Association de Coopération et de Recherche pour le Développement</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47099</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21047</code>
             <name>
-                <narrative>University of the South Pacific</narrative>
-                <narrative xml:lang="fr">Université du Pacifique Sud</narrative>
+                <narrative>AgriCord</narrative>
+                <narrative xml:lang="fr">AgriCord</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47056</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21048</code>
             <name>
-                <narrative>World AgroForestry Centre</narrative>
-                <narrative xml:lang="fr">Centre mondial de l’agroforesterie</narrative>
+                <narrative>Association of African Universities</narrative>
+                <narrative xml:lang="fr">Association des universités africaines</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
-            <code>47103</code>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21049</code>
             <name>
-                <narrative>World Maritime University</narrative>
-                <narrative xml:lang="fr">Université maritime mondiale</narrative>
+                <narrative>European Centre for Development Policy Management</narrative>
+                <narrative xml:lang="fr">Centre européen de gestion de politiques de développement</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21050</code>
+            <name>
+                <narrative>Geneva Call</narrative>
+                <narrative xml:lang="fr">Appel de Genève</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21051</code>
+            <name>
+                <narrative>Institut Supérieur Panafricaine d’Economie Coopérative</narrative>
+                <narrative xml:lang="fr">Institut supérieur panafricaine d’economie coopérative</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21053</code>
+            <name>
+                <narrative>IPAS-Protecting Women’s Health, Advancing Women’s Reproductive Rights</narrative>
+                <narrative xml:lang="fr">IPAS-Protecting Women's Health, Advancing Women's Reproductive Rights</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21054</code>
+            <name>
+                <narrative>Life and Peace Institute</narrative>
+                <narrative xml:lang="fr">Institut Vie et Paix</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21055</code>
+            <name>
+                <narrative>Regional AIDS Training Network</narrative>
+                <narrative xml:lang="fr">Réseau régional de formation sur le SIDA</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21056</code>
+            <name>
+                <narrative>Renewable Energy and Energy Efficiency Partnership</narrative>
+                <narrative xml:lang="fr">Partenariat pour les énergies renouvelables et l'efficience énergétique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>21057</code>
+            <name>
+                <narrative>International Centre for Transitional Justice</narrative>
+                <narrative xml:lang="fr">Centre International pour la Justice Transitionnelle</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21058</code>
+            <name>
+                <narrative>International Crisis Group</narrative>
+                <narrative xml:lang="fr">International Crisis Group</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21059</code>
+            <name>
+                <narrative>Africa Solidarity Fund</narrative>
+                <narrative xml:lang="fr">Fonds solidaire pour l'Afrique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21060</code>
+            <name>
+                <narrative>Association for the Prevention of Torture</narrative>
+                <narrative xml:lang="fr">Association pour la prévention de la torture</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>21061</code>
+            <name>
+                <narrative>International Rehabilitation Council for Torture Victims</narrative>
+                <narrative xml:lang="fr">Conseil international de réhabilitation pour les victimes de torture</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>21062</code>
+            <name>
+                <narrative>The Nature Conservancy</narrative>
+                <narrative xml:lang="fr">The Nature Conservancy</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
+            <code>21063</code>
+            <name>
+                <narrative>Conservation International</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>21064</code>
+            <name>
+                <narrative>Clinton Health Access Initiative, Inc.</narrative>
+                <narrative xml:lang="fr">Initiative Clinton pour l'accès à la santé</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>21501</code>
+            <name>
+                <narrative>OXFAM International</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>21502</code>
+            <name>
+                <narrative>World Vision</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>21503</code>
+            <name>
+                <narrative>Family Health International 360</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>21504</code>
+            <name>
+                <narrative>International Relief and Development</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>21505</code>
+            <name>
+                <narrative>Save the Children</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>21506</code>
+            <name>
+                <narrative>International Rescue Committee</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>21507</code>
+            <name>
+                <narrative>Pact World</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>22000</code>
+            <name>
+                <narrative>Donor country-based NGO</narrative>
+                <narrative xml:lang="fr">ONG basée dans un pays donneur</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>22501</code>
+            <name>
+                <narrative>OXFAM - provider country office</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>22502</code>
+            <name>
+                <narrative>Save the Children - donor country office</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>23000</code>
+            <name>
+                <narrative>Developing country-based NGO</narrative>
+                <narrative xml:lang="fr">ONG basée dans un pays en développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
+            <code>23501</code>
+            <name>
+                <narrative>National Red Cross and Red Crescent Societies</narrative>
+                <narrative xml:lang="fr">Sociétés nationales de la Croix-Rouge et du Croissant-Rouge</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>23000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>30000</code>
+            <name>
+                <narrative>Public-Private Partnerships (PPP) and Networks</narrative>
+                <narrative xml:lang="fr">Partenariats public-privé (PPP) et réseaux</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30001</code>
+            <name>
+                <narrative>Global Alliance for Improved Nutrition</narrative>
+                <narrative xml:lang="fr">Alliance mondiale pour une meilleure nutrition</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30003</code>
+            <name>
+                <narrative>Global e-Schools and Communities Initiative</narrative>
+                <narrative xml:lang="fr">Initiative mondiale en faveur de l’informatique dans les écoles et dans les communautés</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30004</code>
+            <name>
+                <narrative>Global Water Partnership</narrative>
+                <narrative xml:lang="fr">Partenariat mondial pour l'eau</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30005</code>
+            <name>
+                <narrative>International AIDS Vaccine Initiative</narrative>
+                <narrative xml:lang="fr">Initiative internationale pour un vaccin contre le SIDA</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30006</code>
+            <name>
+                <narrative>International Partnership on Microbicides</narrative>
+                <narrative xml:lang="fr">Partenariat international pour des microbicides</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30007</code>
+            <name>
+                <narrative>Global Alliance for ICT and Development</narrative>
+                <narrative xml:lang="fr">Alliance mondiale pour les TIC et le développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30008</code>
+            <name>
+                <narrative>Cities Alliance</narrative>
+                <narrative xml:lang="fr">Alliance pour les villes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30009</code>
+            <name>
+                <narrative>Small Arms Survey</narrative>
+                <narrative xml:lang="fr">Small Arms Survey</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>30010</code>
+            <name>
+                <narrative>International drug purchase facility</narrative>
+                <narrative xml:lang="fr">Facilité internationale d'achat de médicaments</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30011</code>
+            <name>
+                <narrative>International Union for the Conservation of Nature</narrative>
+                <narrative xml:lang="fr">Union internationale pour la conservation de la nature</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30012</code>
+            <name>
+                <narrative>Global Climate Partnership Fund</narrative>
+                <narrative xml:lang="fr">Global Climate Partnership Fund</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30013</code>
+            <name>
+                <narrative>Microfinance Enhancement Facility</narrative>
+                <narrative xml:lang="fr">Mécanisme de soutien au microfinancement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30014</code>
+            <name>
+                <narrative>Regional Micro, Small and Medium Enterprise Investment Fund for Sub-Saharan Africa</narrative>
+                <narrative xml:lang="fr">Fonds régional d’investissement pour les très petites, petites et moyennes entreprises d’Afrique subsaharienne</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>30015</code>
+            <name>
+                <narrative>Global Energy Efficiency and Renewable Energy Fund</narrative>
+                <narrative xml:lang="fr">Fonds mondial pour la promotion de l'efficacité énergétique et des énergies renouvelables</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>30016</code>
+            <name>
+                <narrative>European Fund for Southeast Europe</narrative>
+                <narrative xml:lang="fr">European Fund for Southeast Europe</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>30017</code>
+            <name>
+                <narrative>SANAD Fund for Micro, Small and Medium Enterprises</narrative>
+                <narrative xml:lang="fr">SANAD Fund for Micro, Small and Medium Enterprises</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>31000</code>
+            <name>
+                <narrative>Public-Private Partnerships (PPP)</narrative>
+                <narrative xml:lang="fr">Partenariats public-privé (PPP)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>31001</code>
+            <name>
+                <narrative>Global Development Network</narrative>
+                <narrative xml:lang="fr">Réseau de développement mondial</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>31002</code>
+            <name>
+                <narrative>Global Knowledge Partnership</narrative>
+                <narrative xml:lang="fr">Alliance mondiale pour le savoir</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>31003</code>
+            <name>
+                <narrative>International Land Coalition</narrative>
+                <narrative xml:lang="fr">Coalition internationale pour l'accès à la terre</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>31004</code>
+            <name>
+                <narrative>Extractive Industries Transparency Initiative International Secretariat</narrative>
+                <narrative xml:lang="fr">Secrétariat de l'Initiative pour la transparence dans les industries extractives</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>31005</code>
+            <name>
+                <narrative>Parliamentary Network on the World Bank</narrative>
+                <narrative xml:lang="fr">Réseau parlementaire sur la Banque mondaile</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>31006</code>
+            <name>
+                <narrative>Coalition for Epidemic Preparedness Innovations</narrative>
+                <narrative xml:lang="fr">Coalition pour les innovations en matière de préparation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>32000</code>
+            <name>
+                <narrative>Networks</narrative>
+                <narrative xml:lang="fr">Réseaux</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>40000</code>
+            <name>
+                <narrative>Multilateral Organisations</narrative>
+                <narrative xml:lang="fr">Organisations multilatérales</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>41000</code>
+            <name>
+                <narrative>United Nations (UN) agency, fund or commission</narrative>
+                <narrative xml:lang="fr">Agence, fonds ou commission des Nations Unies (ONU)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>41101</code>
+            <name>
+                <narrative>Convention to Combat Desertification</narrative>
+                <narrative xml:lang="fr">Convention sur la lutte contre la désertification</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41102</code>
+            <name>
+                <narrative>Desert Locust Control Organisation for Eastern Africa</narrative>
+                <narrative xml:lang="fr">Organisation de lutte contre le criquet pèlerin dans l'Est Africain</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41103</code>
+            <name>
+                <narrative>Economic Commission for Africa</narrative>
+                <narrative xml:lang="fr">Commission économique pour l'Afrique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2005-01-01" withdrawal-date="2005-12-31">
+            <code>41104</code>
+            <name>
+                <narrative>Economic Commission for Latin America and the Caribbean</narrative>
+                <narrative xml:lang="fr">Commission économique pour l'Amérique latine et les Caraïbes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2005-01-01" withdrawal-date="2005-12-31">
+            <code>41105</code>
+            <name>
+                <narrative>Economic and Social Commission for Western Asia</narrative>
+                <narrative xml:lang="fr">Commission économique et sociale pour l'Asie occidentale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41106</code>
+            <name>
+                <narrative>Economic and Social Commission for Asia and the Pacific</narrative>
+                <narrative xml:lang="fr">Commission économique et sociale pour l'Asie et le Pacifique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>41107</code>
+            <name>
+                <narrative>International Atomic Energy Agency (Contributions to Technical Cooperation Fund Only)</narrative>
+                <narrative xml:lang="fr">Agence internationale de l'énergie atomique (Contributions au Fonds de Coopération Technique uniquement)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41108</code>
+            <name>
+                <narrative>International Fund for Agricultural Development</narrative>
+                <narrative xml:lang="fr">Fonds international de développement agricole</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>41109</code>
+            <name>
+                <narrative>International Research and Training Institute for the Advancement of Women</narrative>
+                <narrative xml:lang="fr">International Research and Training Institute for the Advancement of Women</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41110</code>
+            <name>
+                <narrative>Joint United Nations Programme on HIV/AIDS</narrative>
+                <narrative xml:lang="fr">Programme commun des Nations Unies sur le VIH/SIDA</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2000-01-01">
+            <code>41111</code>
+            <name>
+                <narrative>United Nations Capital Development Fund</narrative>
+                <narrative xml:lang="fr">Fonds d’équipement des Nations Unies</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41112</code>
+            <name>
+                <narrative>United Nations Conference on Trade and Development</narrative>
+                <narrative xml:lang="fr">Conférence des Nations Unies sur le commerce et le développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41114</code>
+            <name>
+                <narrative>United Nations Development Programme</narrative>
+                <narrative xml:lang="fr">Programme des Nations Unies pour le développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41116</code>
+            <name>
+                <narrative>United Nations Environment Programme</narrative>
+                <narrative xml:lang="fr">Programme des Nations Unies pour l'environnement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>41119</code>
+            <name>
+                <narrative>United Nations Population Fund</narrative>
+                <narrative xml:lang="fr">Fonds des Nations Unies pour la population</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2003-01-01" withdrawal-date="2003-12-31">
+            <code>41120</code>
+            <name>
+                <narrative>United Nations Human Settlement Programme</narrative>
+                <narrative xml:lang="fr">Programme des Nations Unies pour les établissements humains</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41121</code>
+            <name>
+                <narrative>United Nations Office of the United Nations High Commissioner for Refugees</narrative>
+                <narrative xml:lang="fr">Haut Commissariat des Nations Unies pour les réfugiés</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41122</code>
+            <name>
+                <narrative>United Nations Children’s Fund</narrative>
+                <narrative xml:lang="fr">Fonds des Nations Unies pour l'enfance</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41123</code>
+            <name>
+                <narrative>United Nations Industrial Development Organisation</narrative>
+                <narrative xml:lang="fr">Organisation des Nations Unies pour le développement industriel</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>41124</code>
+            <name>
+                <narrative>United Nations Development Fund for Women</narrative>
+                <narrative xml:lang="fr">United Nations Development Fund for Women</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41125</code>
+            <name>
+                <narrative>United Nations Institute for Training and Research</narrative>
+                <narrative xml:lang="fr">Institut des Nations Unies pour la formation et la recherche</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2002-01-01">
+            <code>41126</code>
+            <name>
+                <narrative>United Nations Mine Action Service</narrative>
+                <narrative xml:lang="fr">Service de l'action antimines des Nations Unies</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2005-01-01" withdrawal-date="2005-12-31">
+            <code>41127</code>
+            <name>
+                <narrative>United Nations Office of Co-ordination of Humanitarian Affairs</narrative>
+                <narrative xml:lang="fr">Bureau des Nations Unies pour la coordination de l'assistance humanitaire</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>41128</code>
+            <name>
+                <narrative>United Nations Office on Drugs and Crime</narrative>
+                <narrative xml:lang="fr">Office des Nations Unies contre la drogue et le crime</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>41129</code>
+            <name>
+                <narrative>United Nations Research Institute for Social Development</narrative>
+                <narrative xml:lang="fr">Institut de recherche des Nations Unies pour le développement social</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>41130</code>
+            <name>
+                <narrative>United Nations Relief and Works Agency for Palestine Refugees in the Near East</narrative>
+                <narrative xml:lang="fr">Office de secours et de travaux des Nations Unies pour les réfugiés de Palestine dans le Proche-Orient</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>41131</code>
+            <name>
+                <narrative>United Nations System Staff College</narrative>
+                <narrative xml:lang="fr">Ecole des cadres du système des Nations Unies</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>41132</code>
+            <name>
+                <narrative>United Nations System Standing Committee on Nutrition</narrative>
+                <narrative xml:lang="fr">Comité permanent de la nutrition du système des Nations Unies</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41133</code>
+            <name>
+                <narrative>United Nations Special Initiative on Africa</narrative>
+                <narrative xml:lang="fr">Initiative spéciale des Nations Unies pour l'Afrique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41134</code>
+            <name>
+                <narrative>United Nations University (including Endowment Fund)</narrative>
+                <narrative xml:lang="fr">Université des Nations Unies (y compris le Fonds de dotation)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41135</code>
+            <name>
+                <narrative>United Nations Volunteers</narrative>
+                <narrative xml:lang="fr">Programme des volontaires des Nations Unies</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2001-01-01">
+            <code>41136</code>
+            <name>
+                <narrative>United Nations Voluntary Fund on Disability</narrative>
+                <narrative xml:lang="fr">Fonds de contributions voluntaires des Nations Unies pour les handicapés</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41137</code>
+            <name>
+                <narrative>United Nations Voluntary Fund for Technical Co-operation in the Field of Human Rights</narrative>
+                <narrative xml:lang="fr">Fonds de contributions volontaires des Nations Unies pour la coopération technique dans le domaine des droits de l'homme</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2002-01-01" withdrawal-date="2002-12-31">
+            <code>41138</code>
+            <name>
+                <narrative>United Nations Voluntary Fund for Victims of Torture</narrative>
+                <narrative xml:lang="fr">Fonds de contributions volontaires des Nations Unies pour les victimes de la torture</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>41140</code>
+            <name>
+                <narrative>World Food Programme</narrative>
+                <narrative xml:lang="fr">Programme alimentaire mondial</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>41141</code>
+            <name>
+                <narrative>United Nations Peacebuilding Fund (Window Two:  Restricted Contributions Only)</narrative>
+                <narrative xml:lang="fr">Fonds des Nations Unies pour la consolidation de la paix (Guichet deux:  contributions réservées)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>41142</code>
+            <name>
+                <narrative>United Nations Democracy Fund</narrative>
+                <narrative xml:lang="fr">Fonds des Nations Unies pour la démocratie</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2009-01-01">
+            <code>41143</code>
+            <name>
+                <narrative>World Health Organisation - core voluntary contributions account</narrative>
+                <narrative xml:lang="fr">Organisation mondiale de la santé - compte de contributions volontaires sans objet désigné</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41144</code>
+            <name>
+                <narrative>International Labour Organisation - Regular Budget Supplementary Account</narrative>
+                <narrative xml:lang="fr">Organisation internationale du Travail - Compte supplémentaire du budget ordinaire</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>41145</code>
+            <name>
+                <narrative>International Maritime Organization - Technical Co-operation Fund</narrative>
+                <narrative xml:lang="fr">Organisation maritime internationale - Programme intégré de coopération technique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>41146</code>
+            <name>
+                <narrative>United Nations Entity for Gender Equality and the Empowerment of Women</narrative>
+                <narrative xml:lang="fr">Entité des Nations Unies pour l'égalité des sexes et l'autonomisation de la femme</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>41147</code>
+            <name>
+                <narrative>Central Emergency Response Fund</narrative>
+                <narrative xml:lang="fr">Fonds central pour les interventions d'urgence</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>41148</code>
+            <name>
+                <narrative>United Nations Department of Political Affairs, Trust Fund in Support of Political Affairs</narrative>
+                <narrative xml:lang="fr">Département des affaires politiques des Nations unies, fonds fiduciaire de soutien aux affaires politiques</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2018-01-01">
+            <code>41149</code>
+            <name>
+                <narrative>United Nations Development Coordination Office</narrative>
+                <narrative xml:lang="fr">Bureau de la coordination des activités de développement des Nations Unies</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2018-01-01">
+            <code>41150</code>
+            <name>
+                <narrative>United Nations Institute for Disarmament Research</narrative>
+                <narrative xml:lang="fr">Institut des Nations unies pour la recherche sur le désarmement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>41300</code>
+            <name>
+                <narrative>Other UN (Core Contributions Reportable in Part)</narrative>
+                <narrative xml:lang="fr">Autres Nations Unies (contributions comptabilisables pour partie)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2018-01-01">
+            <code>41301</code>
+            <name>
+                <narrative>Food and Agricultural Organisation</narrative>
+                <narrative xml:lang="fr">Organisation des Nations Unies pour l'alimentation et l'agriculture</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41302</code>
+            <name>
+                <narrative>International Labour Organisation - Assessed Contributions</narrative>
+                <narrative xml:lang="fr">Organisation internationale du travail - contributions obligatoires</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41303</code>
+            <name>
+                <narrative>International Telecommunications Union</narrative>
+                <narrative xml:lang="fr">Union internationale des télécommunications</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41304</code>
+            <name>
+                <narrative>United Nations Educational, Scientific and Cultural Organisation</narrative>
+                <narrative xml:lang="fr">Organisation des Nations Unies pour l’éducation, la science et la culture</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2013-01-01">
+            <code>41305</code>
+            <name>
+                <narrative>United Nations</narrative>
+                <narrative xml:lang="fr">Organisation des Nations Unies</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41306</code>
+            <name>
+                <narrative>Universal Postal Union</narrative>
+                <narrative xml:lang="fr">Union postale universelle</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41307</code>
+            <name>
+                <narrative>World Health Organisation - assessed contributions</narrative>
+                <narrative xml:lang="fr">Organisation mondiale de la santé - contributions obligatoires</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41308</code>
+            <name>
+                <narrative>World Intellectual Property Organisation</narrative>
+                <narrative xml:lang="fr">Organisation mondiale de la propriété intellectuelle</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41309</code>
+            <name>
+                <narrative>World Meteorological Organisation</narrative>
+                <narrative xml:lang="fr">Organisation météorologique mondiale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
+            <code>41310</code>
+            <name>
+                <narrative>United Nations Department of Peacekeeping Operations [only MINURSO, MINUSCA, MINUSMA, MINUJUSTH, MONUSCO, UNAMID, UNIFIL, UNISFA, UNMIK, UNMIL, UNMISS, UNOCI]. Report contributions mission by mission in CRS++.</narrative>
+                <narrative xml:lang="fr">Département des opérations de maintien de la paix des Nations unies [seulement MINURSO, MINUSCA, MINUSMA, MINUJUSTH, MONUSCO, MINUAD, FINUL, FISNUA, MINUK, MINUL, UNMISS, ONUCI]. Notifier les contributions mission par mission au format SNPC++.</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41311</code>
+            <name>
+                <narrative>United Nations Peacebuilding Fund (Window One:  Flexible Contributions Only)</narrative>
+                <narrative xml:lang="fr">Fonds des Nations Unies pour la consolidation de la paix (Guichet un:  contributions sans conditions)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41312</code>
+            <name>
+                <narrative>International Atomic Energy Agency - assessed contributions</narrative>
+                <narrative xml:lang="fr">Agence internationale de l'énergie atomique - contributions obligatoires</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
+            <code>41313</code>
+            <name>
+                <narrative>United Nations High Commissioner for Human Rights (extrabudgetary contributions only)</narrative>
+                <narrative xml:lang="fr">Haut-Commissariat des Nations unies aux droits de l'homme (contributions extrabudgétaires uniquement)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41314</code>
+            <name>
+                <narrative>United Nations Economic Commission for Europe (extrabudgetary contributions only)</narrative>
+                <narrative xml:lang="fr">Commission économique des Nations unies pour l'Europe (contributions extrabudgétaires uniquement)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41315</code>
+            <name>
+                <narrative>United Nations International Strategy for Disaster Reduction</narrative>
+                <narrative xml:lang="fr">Stratégie internationale des Nations Unies pour la prévention de catastrophes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>41316</code>
+            <name>
+                <narrative>United Nations Framework Convention on Climate Change</narrative>
+                <narrative xml:lang="fr">Convention-cadre des Nations unies sur les changements climatiques</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2015-01-01">
+            <code>41317</code>
+            <name>
+                <narrative>Green Climate Fund</narrative>
+                <narrative xml:lang="fr">Fonds vert pour le climat</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>41318</code>
+            <name>
+                <narrative>Global Mechanism</narrative>
+                <narrative xml:lang="fr">Mécanisme mondial</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
+            <code>41319</code>
+            <name>
+                <narrative>World Tourism Organization</narrative>
+                <narrative xml:lang="fr">Organisation mondiale du tourisme</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>41320</code>
+            <name>
+                <narrative>Technology Bank for Least Developed Countries</narrative>
+                <narrative xml:lang="fr">Banque de Technologies en faveur des Pays les Moins Avancés</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>41501</code>
+            <name>
+                <narrative>United Nations Reducing Emissions from Deforestation and Forest Degradation</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>41502</code>
+            <name>
+                <narrative>United Nations Office for Project Services</narrative>
+                <narrative xml:lang="fr">Le Bureau des Nations Unies pour les services d'appui aux projets</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
+            <code>41503</code>
+            <name>
+                <narrative>UN-led Country-based Pooled Funds</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>42000</code>
+            <name>
+                <narrative>European Union Institutions</narrative>
+                <narrative xml:lang="fr">Institutions de l'Union européenne</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>42001</code>
+            <name>
+                <narrative>European Commission - Development Share of Budget</narrative>
+                <narrative xml:lang="fr">Commission européenne - partie du budget affectée au développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>42000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>42003</code>
+            <name>
+                <narrative>European Commission - European Development Fund</narrative>
+                <narrative xml:lang="fr">Commission européenne - Fonds européen de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>42000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>42004</code>
+            <name>
+                <narrative>European Investment Bank</narrative>
+                <narrative xml:lang="fr">Banque européenne d'investissement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>42000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2009-01-01" withdrawal-date="2009-12-31">
+            <code>42005</code>
+            <name>
+                <narrative>Facility for Euro-Mediterranean Investment and Partnership Trust Fund</narrative>
+                <narrative xml:lang="fr">Facility for Euro-Mediterranean Investment and Partnership Trust Fund</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>42000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>43000</code>
+            <name>
+                <narrative>International Monetary Fund (IMF)</narrative>
+                <narrative xml:lang="fr">Fonds monétaire international (FMI)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2009-01-01" withdrawal-date="2009-12-31">
+            <code>43001</code>
+            <name>
+                <narrative>International Monetary Fund - Poverty Reduction and Growth Trust</narrative>
+                <narrative xml:lang="fr">Fonds monétaire international – Facilité pour la réduction de la pauvreté et pour la croissance</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>43000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2009-01-01" withdrawal-date="2009-12-31">
+            <code>43002</code>
+            <name>
+                <narrative>International Monetary Fund - Poverty Reduction and Growth - Heavily Indebted Poor Countries Debt Relief Initiative Trust Fund [includes HIPC, Extended Credit Facility (ECF), and ECF-HIPC sub-accounts]</narrative>
+                <narrative xml:lang="fr">Fonds monétaire international – Réduction de la pauvreté et croissance – Initiative d’allègement de la dette en faveur des pays pauvres très endettés [y compris Initiative PPTE, Facilité élargie de crédit (FEC) et sous-comptes (FEC-PPTE)]</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>43000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2009-01-01" withdrawal-date="2009-12-31">
+            <code>43003</code>
+            <name>
+                <narrative>International Monetary Fund - Subsidization of Emergency Post Conflict Assistance/Emergency Assistance for Natural Disasters for PRGT-eligible members</narrative>
+                <narrative xml:lang="fr">Fonds monétaire international – Aide d’urgence après un conflit (EPCA) et aide d’urgence à la suite de catastrophes naturelles (ENDA) pour les membres pouvant bénéficier de la FRPC</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>43000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>43004</code>
+            <name>
+                <narrative>International Monetary Fund - Poverty Reduction and Growth - Multilateral Debt Relief Initiative Trust</narrative>
+                <narrative xml:lang="fr">Fonds monétaire international – Facilité pour la réduction de la pauvreté et pour la croissance – Initiative d’allègement de la dette multilatérale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>43000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>43005</code>
+            <name>
+                <narrative>International Monetary Fund - Post-Catastrophe Debt Relief Trust</narrative>
+                <narrative xml:lang="fr">Fonds monétaire international  - Fonds fiduciaire pour l'allégement de la dette après une catastrophe</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>43000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2015-01-01">
+            <code>43006</code>
+            <name>
+                <narrative>Catastrophe Containment and Relief Trust</narrative>
+                <narrative xml:lang="fr">Fonds fiduciaire d’assistance et de riposte aux catastrophes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>43000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>44000</code>
+            <name>
+                <narrative>World Bank Group (WB)</narrative>
+                <narrative xml:lang="fr">Groupe de la Banque mondiale (BM)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>44001</code>
+            <name>
+                <narrative>International Bank for Reconstruction and Development</narrative>
+                <narrative xml:lang="fr">Banque internationale pour la reconstruction et le développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>44000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>44002</code>
+            <name>
+                <narrative>International Development Association</narrative>
+                <narrative xml:lang="fr">Association internationale de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>44000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>44003</code>
+            <name>
+                <narrative>International Development Association - Heavily Indebted Poor Countries Debt Initiative Trust Fund</narrative>
+                <narrative xml:lang="fr">Association internationale de développement - Fonds fiduciaire de l'IDA en faveur des pays pauvres très endettés</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>44000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>44004</code>
+            <name>
+                <narrative>International Finance Corporation</narrative>
+                <narrative xml:lang="fr">Société financière internationale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>44000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>44005</code>
+            <name>
+                <narrative>Multilateral Investment Guarantee Agency</narrative>
+                <narrative xml:lang="fr">Agence multilatérale de garantie des investissements</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>44000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2007-01-01">
+            <code>44006</code>
+            <name>
+                <narrative>Advance Market Commitments</narrative>
+                <narrative xml:lang="fr">Garanties de marché</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>44000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>44007</code>
+            <name>
+                <narrative>International Development Association - Multilateral Debt Relief Initiative</narrative>
+                <narrative xml:lang="fr">Association internationale de développement - Initiative d’allégement de la dette multilatérale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>44000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>45000</code>
+            <name>
+                <narrative>World Trade Organisation (WTO)</narrative>
+                <narrative xml:lang="fr">Organisation mondiale du commerce (OMC)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>45001</code>
+            <name>
+                <narrative>World Trade Organisation - International Trade Centre</narrative>
+                <narrative xml:lang="fr">Centre du commerce international de l'Organisation mondiale du commerce</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>45000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2005-01-01" withdrawal-date="2005-12-31">
+            <code>45002</code>
+            <name>
+                <narrative>World Trade Organisation - Advisory Centre on WTO Law</narrative>
+                <narrative xml:lang="fr">Centre consultatif sur la législation de l'Organisation mondiale du commerce</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>45000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2002-01-01" withdrawal-date="2002-12-31">
+            <code>45003</code>
+            <name>
+                <narrative>World Trade Organisation - Doha Development Agenda Global Trust Fund</narrative>
+                <narrative xml:lang="fr">Organisation mondiale du commerce - Fonds global d'affectation spéciale pour le Programme de Doha pour le développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>45000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>46000</code>
+            <name>
+                <narrative>Regional Development Banks</narrative>
+                <narrative xml:lang="fr">Banques régionales de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2008-01-01" withdrawal-date="2008-12-31">
+            <code>46002</code>
+            <name>
+                <narrative>African Development Bank</narrative>
+                <narrative xml:lang="fr">Banque africaine de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>46003</code>
+            <name>
+                <narrative>African Development Fund</narrative>
+                <narrative xml:lang="fr">Fonds africain de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2008-01-01" withdrawal-date="2008-12-31">
+            <code>46004</code>
+            <name>
+                <narrative>Asian Development Bank</narrative>
+                <narrative xml:lang="fr">Banque asiatique de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>46005</code>
+            <name>
+                <narrative>Asian Development Fund</narrative>
+                <narrative xml:lang="fr">Fonds asiatique de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2009-01-01">
+            <code>46006</code>
+            <name>
+                <narrative>Black Sea Trade and Development Bank</narrative>
+                <narrative xml:lang="fr">Black Sea Trade and Development Bank</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>46007</code>
+            <name>
+                <narrative>Central American Bank for Economic Integration</narrative>
+                <narrative xml:lang="fr">Banque centroaméricaine d'intégration économique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2018-01-01">
+            <code>46008</code>
+            <name>
+                <narrative>Development Bank of Latin America</narrative>
+                <narrative xml:lang="fr">Banque de développement de l'Amérique latine</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>46009</code>
+            <name>
+                <narrative>Caribbean Development Bank</narrative>
+                <narrative xml:lang="fr">Banque de développement des Caraïbes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2008-01-01" withdrawal-date="2008-12-31">
+            <code>46012</code>
+            <name>
+                <narrative>Inter-American Development Bank, Inter-American Investment Corporation and Multilateral Investment Fund</narrative>
+                <narrative xml:lang="fr">Banque interaméricaine de développement, Société interaméricaine d'investissements, Fonds multilatéral d'investissements</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2012-01-01" withdrawal-date="2012-12-31">
+            <code>46013</code>
+            <name>
+                <narrative>Inter-American Development Bank, Fund for Special Operations</narrative>
+                <narrative xml:lang="fr">Banque interaméricaine de développement, Fonds opérations spécial</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>46015</code>
+            <name>
+                <narrative>European Bank for Reconstruction and Development</narrative>
+                <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>46016</code>
+            <name>
+                <narrative>European Bank for Reconstruction and Development – technical co-operation and special funds (ODA-eligible countries only)</narrative>
+                <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement - coopération technique et fonds spéciaux (pays éligibles à l'APD)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>46017</code>
+            <name>
+                <narrative>European Bank for Reconstruction and Development – technical co-operation and special funds (all EBRD countries of operations)</narrative>
+                <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement - coopération technique et fonds spéciaux (tous pays)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>46018</code>
+            <name>
+                <narrative>European Bank for Reconstruction and Development - Early Transition Countries Fund</narrative>
+                <narrative xml:lang="fr">Banque européenne de reconstruction et de développement - Initiative en faveur des pays en transition précoce</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>46019</code>
+            <name>
+                <narrative>European Bank for Reconstruction and Development - Western Balkans Joint Trust Fund</narrative>
+                <narrative xml:lang="fr">Banque européenne de reconstruction et de développement - Fonds spécial pour les Balkans occidentaux</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>46020</code>
+            <name>
+                <narrative>Central African States Development Bank</narrative>
+                <narrative xml:lang="fr">Banque de développement des États de l'Afrique Centrale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>46021</code>
+            <name>
+                <narrative>West African Development Bank</narrative>
+                <narrative xml:lang="fr">Banque ouest-africaine de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2013-01-01">
+            <code>46022</code>
+            <name>
+                <narrative>African Export Import Bank</narrative>
+                <narrative xml:lang="fr">Banque Africaine d'Import-Export</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2013-01-01">
+            <code>46023</code>
+            <name>
+                <narrative>Eastern and Southern African Trade and Development Bank</narrative>
+                <narrative xml:lang="fr">Banque de l’Afrique de l’Est et de l’Afrique Australe pour le Commerce et le Développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>46024</code>
+            <name>
+                <narrative>Council of Europe Development Bank</narrative>
+                <narrative xml:lang="fr">Banque de Développement du Conseil de l'Europe</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>46025</code>
+            <name>
+                <narrative>Islamic Development Bank</narrative>
+                <narrative xml:lang="fr">Banque Islamique de Développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
+            <code>46026</code>
+            <name>
+                <narrative>Asian Infrastructure Investment Bank</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>46027</code>
+            <name>
+                <narrative>Financial Fund for the Development of the River Plate Basin</narrative>
+                <narrative xml:lang="fr">Fonds financier pour le développement du bassin fluvial de la Plata</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>47000</code>
+            <name>
+                <narrative>Other multilateral institutions</narrative>
+                <narrative xml:lang="fr">Autres institutions multilatérales</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2001-01-01">
+            <code>47001</code>
+            <name>
+                <narrative>African Capacity Building Foundation</narrative>
+                <narrative xml:lang="fr">Fondation pour le renforcement des capacités en Afrique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47002</code>
+            <name>
+                <narrative>Asian Productivity Organisation</narrative>
+                <narrative xml:lang="fr">Organisation asiatique de productivité</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47003</code>
+            <name>
+                <narrative>Association of South East Asian Nations: Economic Co-operation</narrative>
+                <narrative xml:lang="fr">Association des nations de l'Asie du Sud-Est - coopération économique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47004</code>
+            <name>
+                <narrative>ASEAN Cultural Fund</narrative>
+                <narrative xml:lang="fr">ASEAN Cultural Fund</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2002-01-01" withdrawal-date="2002-12-31">
+            <code>47005</code>
+            <name>
+                <narrative>African Union (excluding peacekeeping facilities)</narrative>
+                <narrative xml:lang="fr">Union Africaine (à l'exclusion de la Facilité de soutien à la paix)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
             <code>47008</code>
             <name>
                 <narrative>World Vegetable Centre</narrative>
                 <narrative xml:lang="fr">Centre international de cultures maraîchères</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47009</code>
+            <name>
+                <narrative>African and Malagasy Council for Higher Education</narrative>
+                <narrative xml:lang="fr">Conseil africain et malgache pour l'enseignement supérieur</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47010</code>
+            <name>
+                <narrative>Commonwealth Agency for Public Administration and Management</narrative>
+                <narrative xml:lang="fr">Agence du Commonwealth pour l'administration et la gestion publiques</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2005-01-01">
+            <code>47011</code>
+            <name>
+                <narrative>Caribbean Community Secretariat</narrative>
+                <narrative xml:lang="fr">Secrétariat de la Communauté des Caraïbes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>47012</code>
+            <name>
+                <narrative>Caribbean Epidemiology Centre</narrative>
+                <narrative xml:lang="fr">Centre épidémiologique des Caraïbes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47013</code>
+            <name>
+                <narrative>Commonwealth Foundation</narrative>
+                <narrative xml:lang="fr">Fondation du Commonwealth</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47014</code>
+            <name>
+                <narrative>Commonwealth Fund for Technical Co-operation</narrative>
+                <narrative xml:lang="fr">Commonwealth Fund for Technical Co-operation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2011-01-01" withdrawal-date="2011-12-31">
+            <code>47015</code>
+            <name>
+                <narrative>CGIAR Fund</narrative>
+                <narrative xml:lang="fr">CGIAR Fund</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2009-01-01" withdrawal-date="2009-12-31">
+            <code>47016</code>
+            <name>
+                <narrative>Commonwealth Institute</narrative>
+                <narrative xml:lang="fr">Commonwealth Institute</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47017</code>
+            <name>
+                <narrative>International Centre for Tropical Agriculture</narrative>
+                <narrative xml:lang="fr">Centre international d'agriculture tropicale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47018</code>
+            <name>
+                <narrative>Centre for International Forestry Research</narrative>
+                <narrative xml:lang="fr">Centre de recherche forestière internationale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47019</code>
+            <name>
+                <narrative>International Centre for Advanced Mediterranean Agronomic Studies</narrative>
+                <narrative xml:lang="fr">Centre international de hautes études agronomique méditerranéennes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47020</code>
+            <name>
+                <narrative>International Maize and Wheat Improvement Centre</narrative>
+                <narrative xml:lang="fr">Centre international d’amélioration du maïs et du blé</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47021</code>
+            <name>
+                <narrative>International Potato Centre</narrative>
+                <narrative xml:lang="fr">Centre international de la pomme de terre</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47022</code>
+            <name>
+                <narrative>Convention on International Trade in Endangered Species of Wild Flora and Fauna</narrative>
+                <narrative xml:lang="fr">Convention sur le commerce international des espèces de faune et de flore sauvages menacées d'extinction</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47023</code>
+            <name>
+                <narrative>Commonwealth Legal Advisory Service</narrative>
+                <narrative xml:lang="fr">Commonwealth Legal Advisory Service</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47024</code>
+            <name>
+                <narrative>Commonwealth Media Development Fund</narrative>
+                <narrative xml:lang="fr">Commonwealth Media Development Fund</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47025</code>
+            <name>
+                <narrative>Commonwealth of Learning</narrative>
+                <narrative xml:lang="fr">Commonwealth of Learning</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2006-01-01" withdrawal-date="2006-12-31">
+            <code>47026</code>
+            <name>
+                <narrative>Community of Portuguese Speaking Countries</narrative>
+                <narrative xml:lang="fr">Communauté des pays de langue portugaise</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47027</code>
+            <name>
+                <narrative>Colombo Plan</narrative>
+                <narrative xml:lang="fr">Plan de Colombo</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47028</code>
+            <name>
+                <narrative>Commonwealth Partnership for Technical Management</narrative>
+                <narrative xml:lang="fr">Partenariat pour la gestion technique (Commonwealth)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>32000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>47029</code>
+            <name>
+                <narrative>Sahel and West Africa Club</narrative>
+                <narrative xml:lang="fr">Club du Sahel et de l’Afrique de l’Ouest</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2009-01-01" withdrawal-date="2009-12-31">
+            <code>47030</code>
+            <name>
+                <narrative>Commonwealth Scientific Council</narrative>
+                <narrative xml:lang="fr">Commonwealth Scientific Council</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47031</code>
+            <name>
+                <narrative>Commonwealth Small States Office</narrative>
+                <narrative xml:lang="fr">Commonwealth Small States Office</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2009-01-01" withdrawal-date="2009-12-31">
+            <code>47032</code>
+            <name>
+                <narrative>Commonwealth Trade and Investment Access Facility</narrative>
+                <narrative xml:lang="fr">Commonwealth Trade and Investment Access Facility</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47033</code>
+            <name>
+                <narrative>Commonwealth Youth Programme</narrative>
+                <narrative xml:lang="fr">Commonwealth Youth Programme</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>47034</code>
+            <name>
+                <narrative>Economic Community of West African States</narrative>
+                <narrative xml:lang="fr">Communauté économique des Etats de l’Afrique de l’Ouest</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47035</code>
+            <name>
+                <narrative>Environmental Development Action in the Third World</narrative>
+                <narrative xml:lang="fr">Environnement et développement du Tiers-monde</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47036</code>
+            <name>
+                <narrative>European and Mediterranean Plant Protection Organisation</narrative>
+                <narrative xml:lang="fr">Organisation Européenne et Méditerranéenne pour la Protection des Plantes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47037</code>
+            <name>
+                <narrative>Eastern-Regional Organisation of Public Administration</narrative>
+                <narrative xml:lang="fr">Organisation régionale de l'Orient pour l'administration publique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47038</code>
+            <name>
+                <narrative>INTERPOL Fund for Aid and Technical Assistance to Developing Countries</narrative>
+                <narrative xml:lang="fr">INTERPOL Fund for Aid and Technical Assistance to Developing Countries</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2006-01-01" withdrawal-date="2006-12-31">
+            <code>47040</code>
+            <name>
+                <narrative>Forum Fisheries Agency</narrative>
+                <narrative xml:lang="fr">Agence des pêches</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47041</code>
+            <name>
+                <narrative>Food and Fertilizer Technology Centre</narrative>
+                <narrative xml:lang="fr">Centre des techniques de l'alimentation et des engrais</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47042</code>
+            <name>
+                <narrative>Foundation for International Training</narrative>
+                <narrative xml:lang="fr">Fondation pour la formation internationale dans les pays du tiers monde</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>22000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47043</code>
+            <name>
+                <narrative>Global Crop Diversity Trust</narrative>
+                <narrative xml:lang="fr">Global Crop Diversity Trust</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>31000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2009-01-01">
+            <code>47044</code>
+            <name>
+                <narrative>Global Environment Facility Trust Fund</narrative>
+                <narrative xml:lang="fr">Fonds pour l'environnement mondial - fonds fiduciaire</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>47045</code>
+            <name>
+                <narrative>Global Fund to Fight AIDS, Tuberculosis and Malaria</narrative>
+                <narrative xml:lang="fr">Fonds mondial de lutte contre le SIDA, la tuberculose et la paludisme</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2006-01-01" withdrawal-date="2006-12-31">
+            <code>47046</code>
+            <name>
+                <narrative>International Organisation of the Francophonie</narrative>
+                <narrative xml:lang="fr">Organisation internationale de la Francophonie</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47047</code>
+            <name>
+                <narrative>International African Institute</narrative>
+                <narrative xml:lang="fr">Institut international africain</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47048</code>
+            <name>
+                <narrative>Inter-American Indian Institute</narrative>
+                <narrative xml:lang="fr">Inter-American Indian Institute</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47049</code>
+            <name>
+                <narrative>International Bureau of Education - International Educational Reporting System (IERS)</narrative>
+                <narrative xml:lang="fr">International Bureau of Education - International Educational Reporting System (IERS)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47050</code>
+            <name>
+                <narrative>International Cotton Advisory Committee</narrative>
+                <narrative xml:lang="fr">Comité consultatif international du coton</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47051</code>
+            <name>
+                <narrative>International Centre for Agricultural Research in Dry Areas</narrative>
+                <narrative xml:lang="fr">Centre international de recherche agricole dans les zones arides</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47053</code>
+            <name>
+                <narrative>International Centre for Diarrhoeal Disease Research, Bangladesh</narrative>
+                <narrative xml:lang="fr">International Centre for Diarrhoeal Disease Research, Bangladesh</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47054</code>
+            <name>
+                <narrative>International Centre of Insect Physiology and Ecology</narrative>
+                <narrative xml:lang="fr">Centre international sur la physiologie et l’écologie des insectes</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47055</code>
+            <name>
+                <narrative>International Centre for Development Oriented Research in Agriculture</narrative>
+                <narrative xml:lang="fr">Centre International pour la Recherche Agricole orientée vers le développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47056</code>
+            <name>
+                <narrative>World AgroForestry Centre</narrative>
+                <narrative xml:lang="fr">Centre mondial de l’agroforesterie</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47057</code>
+            <name>
+                <narrative>International Crop Research for Semi-Arid Tropics</narrative>
+                <narrative xml:lang="fr">Institut international de recherche sur les cultures des zones tropicales semi-arides</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>47058</code>
+            <name>
+                <narrative>International Institute for Democracy and Electoral Assistance</narrative>
+                <narrative xml:lang="fr">International Institute for Democracy and Electoral Assistance</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2005-01-01" withdrawal-date="2005-12-31">
+            <code>47059</code>
+            <name>
+                <narrative>International Development Law Organisation</narrative>
+                <narrative xml:lang="fr">Organisation internationale de droit du développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47060</code>
+            <name>
+                <narrative>International Institute for Cotton</narrative>
+                <narrative xml:lang="fr">International Institute for Cotton</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47061</code>
+            <name>
+                <narrative>Inter-American Institute for Co-operation on Agriculture</narrative>
+                <narrative xml:lang="fr">Institut interaméricain de coopération pour l’agriculture</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47062</code>
+            <name>
+                <narrative>International Institute of Tropical Agriculture</narrative>
+                <narrative xml:lang="fr">Institut international d’agriculture tropicale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47063</code>
+            <name>
+                <narrative>International Livestock Research Institute</narrative>
+                <narrative xml:lang="fr">International Livestock Research Institute</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2005-01-01">
+            <code>47064</code>
+            <name>
+                <narrative>International Network for Bamboo and Rattan</narrative>
+                <narrative xml:lang="fr">Réseau International sur le bambou et le rotin</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47065</code>
+            <name>
+                <narrative>Intergovernmental Oceanographic Commission</narrative>
+                <narrative xml:lang="fr">Commission océanographique intergouvernementale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2018-01-01">
+            <code>47066</code>
+            <name>
+                <narrative>International Organisation for Migration</narrative>
+                <narrative xml:lang="fr">Organisation internationale des migrations</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47067</code>
+            <name>
+                <narrative>Intergovernmental Panel on Climate Change</narrative>
+                <narrative xml:lang="fr">Groupe d’experts intergouvernemental sur l’évolution du climat</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2005-01-01" withdrawal-date="2005-12-31">
+            <code>47068</code>
+            <name>
+                <narrative>Asia-Pacific Fishery Commission</narrative>
+                <narrative xml:lang="fr">Commission Asie-Pacifique des pêches</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47069</code>
+            <name>
+                <narrative>Bioversity International</narrative>
+                <narrative xml:lang="fr">Bioversity International</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47070</code>
+            <name>
+                <narrative>International Rice Research Institute</narrative>
+                <narrative xml:lang="fr">Institut international de recherche sur le riz</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47071</code>
+            <name>
+                <narrative>International Seed Testing Association</narrative>
+                <narrative xml:lang="fr">Association internationale d’essais de semences</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2002-01-01">
+            <code>47073</code>
+            <name>
+                <narrative>International Tropical Timber Organisation</narrative>
+                <narrative xml:lang="fr">Organisation Internationale des Bois Tropicaux</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2000-01-01" withdrawal-date="2000-12-31">
+            <code>47074</code>
+            <name>
+                <narrative>International Vaccine Institute</narrative>
+                <narrative xml:lang="fr">Institut international de vaccins</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47075</code>
+            <name>
+                <narrative>International Water Management Institute</narrative>
+                <narrative xml:lang="fr">Institut international de gestion des ressources en eau</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2005-01-01">
+            <code>47076</code>
+            <name>
+                <narrative>Justice Studies Centre of the Americas</narrative>
+                <narrative xml:lang="fr">Centre d’études sur la justice dans les Amériques</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>47077</code>
+            <name>
+                <narrative>Mekong River Commission</narrative>
+                <narrative xml:lang="fr">Commission du Mékong</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2002-01-01" withdrawal-date="2002-12-31">
+            <code>47078</code>
+            <name>
+                <narrative>Multilateral Fund for the Implementation of the Montreal Protocol</narrative>
+                <narrative xml:lang="fr">Fonds multilatéral pour l’application du Protocole de Montréal</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47079</code>
+            <name>
+                <narrative>Organisation of American States</narrative>
+                <narrative xml:lang="fr">Organisation des États américains</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47080</code>
+            <name>
+                <narrative>Organisation for Economic Co-operation and Development (Contributions to special funds for Technical Co-operation Activities Only)</narrative>
+                <narrative xml:lang="fr">Organisation de Coopération et de développement économiques (contributions aux fonds spéciaux pour les activités de coopération technique uniquement)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2004-01-01">
+            <code>47081</code>
+            <name>
+                <narrative>OECD Development Centre</narrative>
+                <narrative xml:lang="fr">OCDE Centre de développement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2005-01-01">
+            <code>47082</code>
+            <name>
+                <narrative>Organisation of Eastern Caribbean States</narrative>
+                <narrative xml:lang="fr">Organisation des États des Caraïbes orientales</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47083</code>
+            <name>
+                <narrative>Pan-American Health Organisation</narrative>
+                <narrative xml:lang="fr">Organisation panaméricaine de la santé</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47084</code>
+            <name>
+                <narrative>Pan-American Institute of Geography and History</narrative>
+                <narrative xml:lang="fr">Institut panaméricain de géographie et d’histoire</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47085</code>
+            <name>
+                <narrative>Pan-American Railway Congress Association</narrative>
+                <narrative xml:lang="fr">Pan-American Railway Congress Association</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>47086</code>
+            <name>
+                <narrative>Private Infrastructure Development Group</narrative>
+                <narrative xml:lang="fr">Private Infrastructure Development Group</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47087</code>
+            <name>
+                <narrative>Pacific Islands Forum Secretariat</narrative>
+                <narrative xml:lang="fr">Secrétariat du Forum des Iles du Pacifique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47088</code>
+            <name>
+                <narrative>Relief Net</narrative>
+                <narrative xml:lang="fr">Relief Net</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>47089</code>
+            <name>
+                <narrative>Southern African Development Community</narrative>
+                <narrative xml:lang="fr">Communauté pour le développement de l’Afrique australe</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47090</code>
+            <name>
+                <narrative>Southern African Transport and Communications Commission</narrative>
+                <narrative xml:lang="fr">Southern African Transport and Communications Commission</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47091</code>
+            <name>
+                <narrative>(Colombo Plan) Special Commonwealth African Assistance Programme</narrative>
+                <narrative xml:lang="fr">(Colombo Plan) Special Commonwealth African Assistance Programme</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47092</code>
+            <name>
+                <narrative>South East Asian Fisheries Development Centre</narrative>
+                <narrative xml:lang="fr">Centre de développement des pêches de l’Asie du Sud-Est</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47093</code>
+            <name>
+                <narrative>South East Asian Ministers of Education</narrative>
+                <narrative xml:lang="fr">Organisation des Ministres de l’éducation de l’Asie du Sud-Est</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47094</code>
+            <name>
+                <narrative>South Pacific Applied Geoscience Commission</narrative>
+                <narrative xml:lang="fr">South Pacific Applied Geoscience Commission</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2001-01-01">
+            <code>47095</code>
+            <name>
+                <narrative>South Pacific Board for Educational Assessment</narrative>
+                <narrative xml:lang="fr">Conseil d’évaluation du Pacifique Sud pour l'éducation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2007-01-01" withdrawal-date="2007-12-31">
+            <code>47096</code>
+            <name>
+                <narrative>Secretariat of the Pacific Community</narrative>
+                <narrative xml:lang="fr">Secrétariat Général de la Communauté du Pacifique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2005-01-01" withdrawal-date="2005-12-31">
+            <code>47097</code>
+            <name>
+                <narrative>Pacific Regional Environment Programme</narrative>
+                <narrative xml:lang="fr">Programme régional océanien de l’environnement</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="1998-01-01">
+            <code>47098</code>
+            <name>
+                <narrative>Unrepresented Nations and Peoples’ Organisation</narrative>
+                <narrative xml:lang="fr">Organisation des peuples et des nations non représentés</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47099</code>
+            <name>
+                <narrative>University of the South Pacific</narrative>
+                <narrative xml:lang="fr">Université du Pacifique Sud</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2003-01-01">
+            <code>47100</code>
+            <name>
+                <narrative>West African Monetary Union</narrative>
+                <narrative xml:lang="fr">Union monétaire ouest-africaine</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47101</code>
+            <name>
+                <narrative>Africa Rice Centre</narrative>
+                <narrative xml:lang="fr">Centre du riz pour l’Afrique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2012-01-01" withdrawal-date="2012-12-31">
+            <code>47102</code>
+            <name>
+                <narrative>World Customs Organisation Fellowship Programme</narrative>
+                <narrative xml:lang="fr">Organisation mondiale des douanes, programme de bourses</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47103</code>
+            <name>
+                <narrative>World Maritime University</narrative>
+                <narrative xml:lang="fr">Université maritime mondiale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
             <code>47104</code>
             <name>
                 <narrative>WorldFish Centre</narrative>
                 <narrative xml:lang="fr">Centre international pour l’aménagement des ressources bioaquatiques</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
         </codelist-item>
-        <codelist-item status="withdrawn" activation-date="2015-12-07">
+        <codelist-item status="active" activation-date="2002-01-01">
+            <code>47105</code>
+            <name>
+                <narrative>Common Fund for Commodities</narrative>
+                <narrative xml:lang="fr">Fonds commun pour les produits de base</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2007-01-01">
+            <code>47106</code>
+            <name>
+                <narrative>Geneva Centre for the Democratic Control of Armed Forces</narrative>
+                <narrative xml:lang="fr">Centre de contrôle démocratique des forces armées - Genève</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2007-01-01">
+            <code>47107</code>
+            <name>
+                <narrative>International Finance Facility for Immunisation</narrative>
+                <narrative xml:lang="fr">Facilité internationale de financement pour la vaccination</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2010-12-31">
+            <code>47108</code>
+            <name>
+                <narrative>Multi-Country Demobilisation and Reintegration Program</narrative>
+                <narrative xml:lang="fr">Multi-Country Demobilisation and Reintegration Program</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2006-01-01">
+            <code>47109</code>
+            <name>
+                <narrative>Asia-Pacific Economic Cooperation Support Fund (except contributions tied to counter-terrorism activities)</narrative>
+                <narrative xml:lang="fr">Fonds de soutien de la coopération économique Asie-Pacifique (hors lutte contre le terrorisme)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2007-01-01">
+            <code>47110</code>
+            <name>
+                <narrative>Organisation of the Black Sea Economic Cooperation</narrative>
+                <narrative xml:lang="fr">Organisation de coopération économique de la mer Noire</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47111</code>
+            <name>
+                <narrative>Adaptation Fund</narrative>
+                <narrative xml:lang="fr">Fonds pour l’adaptation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47112</code>
+            <name>
+                <narrative>Central European Initiative - Special Fund for Climate and Environmental Protection</narrative>
+                <narrative xml:lang="fr">Initiative de l’Europe centrale - Fonds Spécial pour la protection climatique et environnementale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47113</code>
+            <name>
+                <narrative>Economic and Monetary Community of Central Africa</narrative>
+                <narrative xml:lang="fr">Communauté économique et monétaire de l’Afrique Centrale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47116</code>
+            <name>
+                <narrative>Integrated Framework for Trade-Related Technical Assistance to Least Developed Countries</narrative>
+                <narrative xml:lang="fr">Cadre intégré pour l'assistance technique liée au commerce en faveur des pays les moins avancés</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47117</code>
+            <name>
+                <narrative>New Partnership for Africa's Development</narrative>
+                <narrative xml:lang="fr">Nouveau Partenariat pour le développement de l’Afrique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47118</code>
+            <name>
+                <narrative>Regional Organisation for the Strengthening of Supreme Audit Institutions of Francophone Sub-Saharan Countries</narrative>
+                <narrative xml:lang="fr">Conseil Régional de Formation des Institutions Supérieures de Contrôle des Finances Publiques d’Afrique Francophone Subsaharienne</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47119</code>
+            <name>
+                <narrative>Sahara and Sahel Observatory</narrative>
+                <narrative xml:lang="fr">Observatoire du Sahara et du Sahel</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47120</code>
+            <name>
+                <narrative>South Asian Association for Regional Cooperation</narrative>
+                <narrative xml:lang="fr">Association de l'Asie du Sud pour la coopération régionale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47121</code>
+            <name>
+                <narrative>United Cities and Local Governments of Africa</narrative>
+                <narrative xml:lang="fr">Cités et gouvernements locaux unis d’Afrique</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2008-01-01">
+            <code>47122</code>
+            <name>
+                <narrative>Global Alliance for Vaccines and Immunization</narrative>
+                <narrative xml:lang="fr">Alliance mondiale pour la vaccination et l’immunisation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2006-01-01">
+            <code>47123</code>
+            <name>
+                <narrative>Geneva International Centre for Humanitarian Demining</narrative>
+                <narrative xml:lang="fr">Centre International de Déminage Humanitaire Genève</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2009-01-01">
+            <code>47127</code>
+            <name>
+                <narrative>Latin-American Energy Organisation</narrative>
+                <narrative xml:lang="fr">Organisation latino-américaine de l'énergie</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>47128</code>
+            <name>
+                <narrative>Nordic Development Fund</narrative>
+                <narrative xml:lang="fr">Nordic Development Fund</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>47129</code>
+            <name>
+                <narrative>Global Environment Facility - Least Developed Countries Fund</narrative>
+                <narrative xml:lang="fr">FEM Fonds pour les pays les moins avancés</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2010-01-01">
+            <code>47130</code>
+            <name>
+                <narrative>Global Environment Facility - Special Climate Change Fund</narrative>
+                <narrative xml:lang="fr">FEM Fonds spécial pour les changements climatiques</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2011-01-01">
+            <code>47131</code>
+            <name>
+                <narrative>Organization for Security and Co-operation in Europe</narrative>
+                <narrative xml:lang="fr">Organisation pour la sécurité et la oopération en Europe</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47132</code>
+            <name>
+                <narrative>Commonwealth Secretariat (ODA-eligible contributions only)</narrative>
+                <narrative xml:lang="fr">Secrétariat du Commonwealth (seulement les contributions éligibles à l'APD)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2013-01-01">
+            <code>47134</code>
+            <name>
+                <narrative>Clean Technology Fund</narrative>
+                <narrative xml:lang="fr">Fonds pour les technologies propres</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2012-01-01">
+            <code>47135</code>
+            <name>
+                <narrative>Strategic Climate Fund</narrative>
+                <narrative xml:lang="fr">Fonds stratégique pour le climat</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2013-01-01">
+            <code>47136</code>
+            <name>
+                <narrative>Global Green Growth Institute</narrative>
+                <narrative xml:lang="fr">Institut mondial de la croissance verte</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47137</code>
+            <name>
+                <narrative>African Risk Capacity Group</narrative>
+                <narrative xml:lang="fr">Mutuelle panafricaine de gestion des risques</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47138</code>
+            <name>
+                <narrative>Council of Europe</narrative>
+                <narrative xml:lang="fr">Conseil de l’Europe</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47139</code>
+            <name>
+                <narrative>World Customs Organization Customs Co-operation Fund</narrative>
+                <narrative xml:lang="fr">Organisation Mondiale des Douanes Fonds de coopération douanière</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47140</code>
+            <name>
+                <narrative>Organisation of Ibero-American States for Education, Science and Culture</narrative>
+                <narrative xml:lang="fr">Organisation des états ibéro-américains pour l'éducation, la science et la culture (OEI)</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47141</code>
+            <name>
+                <narrative>African Tax Administration Forum</narrative>
+                <narrative xml:lang="fr">Forum sur l’Administration Fiscale Africaine</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47142</code>
+            <name>
+                <narrative>OPEC Fund for International Development</narrative>
+                <narrative xml:lang="fr">Le Fonds OPEP pour le développement international</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2015-01-01">
+            <code>47143</code>
+            <name>
+                <narrative>Global Community Engagement and Resilience Fund</narrative>
+                <narrative xml:lang="fr">Fonds mondial pour l’engagement de la communauté et la résilience</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2015-01-01">
+            <code>47144</code>
+            <name>
+                <narrative>International Renewable Energy Agency</narrative>
+                <narrative xml:lang="fr">Agence internationale pour les energies renouvelables</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
+            <code>47145</code>
+            <name>
+                <narrative>Center of Excellence in Finance</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2018-01-01">
+            <code>47146</code>
+            <name>
+                <narrative>International Investment Bank</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>47147</code>
+            <name>
+                <narrative>International Finance Facility for Education</narrative>
+                <narrative xml:lang="fr">Facilité internationale de financement pour l'éducation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>47148</code>
+            <name>
+                <narrative>World Organisation for Animal Health</narrative>
+                <narrative xml:lang="fr">Organisation mondiale de la santé animale</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>47400</code>
+            <name>
+                <narrative>European Space Agency (ESA) programme 'Space in support of International Development Aid'</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47501</code>
+            <name>
+                <narrative>Global Partnership for Education</narrative>
+                <narrative xml:lang="fr">Partenariat Mondial pour l'Education</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47502</code>
+            <name>
+                <narrative>Global Fund for Disaster Risk Reduction</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47503</code>
+            <name>
+                <narrative>Global Agriculture and Food Security Program</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>47504</code>
+            <name>
+                <narrative>Forest Carbon Partnership Facility</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
+            <code>50000</code>
+            <name>
+                <narrative>Others</narrative>
+                <narrative xml:lang="fr">Autres</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>51000</code>
+            <name>
+                <narrative>University, college or other teaching institution, research institute or think-tank</narrative>
+                <narrative xml:lang="fr">Université, collège ou autre établissement d'enseignement, institut de recherche ou de réflexion</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2014-01-01">
+            <code>51001</code>
+            <name>
+                <narrative>International Food Policy Research Institute</narrative>
+                <narrative xml:lang="fr">Institut International de Recherche sur les Politiques Alimentaires</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>51000</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>52000</code>
             <name>
                 <narrative>Other</narrative>
                 <narrative xml:lang="fr">Autre</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2016-01-01">
             <code>60000</code>
             <name>
-                <narrative>Private sector institution</narrative>
-                <narrative xml:lang="fr">Institutions du Secteur Privé</narrative>
+                <narrative>Private Sector Institutions</narrative>
+                <narrative xml:lang="fr">Institutions du secteur privé</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2016-01-01">
             <code>61000</code>
             <name>
                 <narrative>Private sector in provider country</narrative>
                 <narrative xml:lang="fr">Secteur privé du pays donneur</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
             <code>61001</code>
             <name>
-                <narrative>Private bank in provider country</narrative>
-                <narrative xml:lang="fr">Banque privée dans le pays donneur</narrative>
+                <narrative>Banks (deposit taking corporations)</narrative>
+                <narrative xml:lang="fr">Banques (institutions de dépôts)</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="withdrawn" activation-date="2017-01-01">
             <code>61002</code>
             <name>
                 <narrative>Private exporter in provider country</narrative>
                 <narrative xml:lang="fr">Exportateur privé dans le pays donneur</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
             <code>61003</code>
             <name>
-                <narrative>Private investor in provider country</narrative>
-                <narrative xml:lang="fr">Investisseur privé dans le pays donneur</narrative>
+                <narrative>Investment funds and other collective investment institutions</narrative>
+                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
             <code>61004</code>
             <name>
-                <narrative>Other non-bank entity in provider country</narrative>
-                <narrative xml:lang="fr">Autre entité non-bancaire dans le pays donneur</narrative>
+                <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
+                <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>61005</code>
+            <name>
+                <narrative>Insurance Corporations</narrative>
+                <narrative xml:lang="fr">Sociétés d’assurance</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>61006</code>
+            <name>
+                <narrative>Pension Funds</narrative>
+                <narrative xml:lang="fr">Fonds de pension</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>61007</code>
+            <name>
+                <narrative>Other financial corporations</narrative>
+                <narrative xml:lang="fr">Autres sociétés financières</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>61008</code>
+            <name>
+                <narrative>Exporters</narrative>
+                <narrative xml:lang="fr">Exportateurs</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>61009</code>
+            <name>
+                <narrative>Other non-financial corporations</narrative>
+                <narrative xml:lang="fr">Autres sociétés non financières</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>61010</code>
+            <name>
+                <narrative>Retail investors</narrative>
+                <narrative xml:lang="fr">Investisseurs individuels</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>61000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
             <code>62000</code>
             <name>
                 <narrative>Private sector in recipient country</narrative>
                 <narrative xml:lang="fr">Secteur privé du pays bénéficiaire</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
             <code>62001</code>
             <name>
-                <narrative>Private bank in recipient country</narrative>
-                <narrative xml:lang="fr">Banque privée dans le pays bénéficiaire</narrative>
+                <narrative>Banks (deposit taking corporations except Micro Finance Institutions)</narrative>
+                <narrative xml:lang="fr">Banques (institutions de dépôts hors institutions de microfinancement)</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
             <code>62002</code>
             <name>
-                <narrative>Joint-venture in recipient country</narrative>
-                <narrative xml:lang="fr">Co-entreprise dans le pays bénéficiaire</narrative>
+                <narrative>Micro Finance Institutions (deposit and non-deposit)</narrative>
+                <narrative xml:lang="fr">Institutions de microfinancement (collectant ou pas des dépôts)</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
             <code>62003</code>
             <name>
-                <narrative>Other non-bank in recipient country</narrative>
-                <narrative xml:lang="fr">Autre entité non-bancaire dans le pays bénéficiaire</narrative>
+                <narrative>Investment funds and other collective investment institutions</narrative>
+                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>62004</code>
+            <name>
+                <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
+                <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>62005</code>
+            <name>
+                <narrative>Insurance Corporations</narrative>
+                <narrative xml:lang="fr">Sociétés d’assurance</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>62006</code>
+            <name>
+                <narrative>Pension Funds</narrative>
+                <narrative xml:lang="fr">Fonds de pension</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>62007</code>
+            <name>
+                <narrative>Other financial corporations</narrative>
+                <narrative xml:lang="fr">Autres sociétés financières</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>62008</code>
+            <name>
+                <narrative>Importers/Exporters</narrative>
+                <narrative xml:lang="fr">Importateurs / Exportateurs</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>62009</code>
+            <name>
+                <narrative>Other non-financial corporations</narrative>
+                <narrative xml:lang="fr">Autres sociétés non financières</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>62010</code>
+            <name>
+                <narrative>Retail investors</narrative>
+                <narrative xml:lang="fr">Investisseurs individuels</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>62000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
             <code>63000</code>
             <name>
                 <narrative>Private sector in third country</narrative>
                 <narrative xml:lang="fr">Secteur privé d'un pays tiers</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
             <code>63001</code>
             <name>
-                <narrative>Private bank in third country</narrative>
-                <narrative xml:lang="fr">Banque privée d'un pays tiers</narrative>
+                <narrative>Banks (deposit taking corporations except Micro Finance Institutions)</narrative>
+                <narrative xml:lang="fr">Banques (institutions de dépôts hors institutions de microfinancement)</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
             <code>63002</code>
             <name>
-                <narrative>Private non-bank in third country</narrative>
-                <narrative xml:lang="fr">Secteur privé non-bancaire dans un pays tiers</narrative>
+                <narrative>Micro Finance Institutions (deposit and non-deposit)</narrative>
+                <narrative xml:lang="fr">Institutions de microfinancement (collectant ou pas des dépôts)</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-03-31">
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>63003</code>
+            <name>
+                <narrative>Investment funds and other collective investment institutions</narrative>
+                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>63004</code>
+            <name>
+                <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
+                <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>63005</code>
+            <name>
+                <narrative>Insurance Corporations</narrative>
+                <narrative xml:lang="fr">Sociétés d’assurance</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>63006</code>
+            <name>
+                <narrative>Pension Funds</narrative>
+                <narrative xml:lang="fr">Fonds de pension</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>63007</code>
+            <name>
+                <narrative>Other financial corporations</narrative>
+                <narrative xml:lang="fr">Autres sociétés financières</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>63008</code>
+            <name>
+                <narrative>Exporters</narrative>
+                <narrative xml:lang="fr">Exportateurs</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>63009</code>
+            <name>
+                <narrative>Other non-financial corporations</narrative>
+                <narrative xml:lang="fr">Autres sociétés non financières</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-01-01">
+            <code>63010</code>
+            <name>
+                <narrative>Retail investors</narrative>
+                <narrative xml:lang="fr">Investisseurs individuels</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>63000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-01-01">
             <code>90000</code>
             <name>
                 <narrative>Other</narrative>
                 <narrative xml:lang="fr">Autre</narrative>
             </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/lib/schemata/non-embedded-codelist/EarmarkingCategory.xml
+++ b/lib/schemata/non-embedded-codelist/EarmarkingCategory.xml
@@ -1,7 +1,7 @@
 <codelist name="EarmarkingCategory" xml:lang="en" complete="1" embedded="0">
     <metadata>
         <name>
-            <narrative>EarmarkingCategory</narrative>
+            <narrative>Earmarking Category</narrative>
         </name>
         <description>
             <narrative>This codelist has been created by IATI and is derived from the Grand Bargain Earmarking Modality codelist.</narrative>

--- a/lib/schemata/non-embedded-codelist/IATIOrganisationIdentifier.xml
+++ b/lib/schemata/non-embedded-codelist/IATIOrganisationIdentifier.xml
@@ -83,6 +83,16 @@
             <url>http://www.aias.gov.mz/</url>
         </codelist-item>
         <codelist-item>
+            <code>XI-IATI-AJS</code>
+            <name>
+                <narrative>Associations des Juristes Sénégalaises (AJS)</narrative>
+            </name>
+            <description>
+                <narrative>The Association des Juristes Sénégalaises (AJS) is an association of women lawyers who promote and contribute to the protection of the rights of individuals, particularly women and children.</narrative>
+            </description>
+            <url>http://www.femmesjuristes.org</url>
+        </codelist-item>        
+        <codelist-item>
             <code>XI-IATI-ATTIC</code>
             <name>
                 <narrative>Association of Technicians in Information Technology and Communication (ATTIC)</narrative>
@@ -91,6 +101,16 @@
                 <narrative>ATTIC, a non-political non-profit association in Republic of Chad, aims to help develop and integrate the promotion of information and communication technologies in the development policy of the formal and non-formal sectors, to fight against food insecurity and poverty, by strengthening the means of vulnerable households, refugees, returnees and internally displaced persons, and by providing socio-professional training and integration for vulnerable groups.</narrative>
             </description>
             <url>Website is still in progress</url>
+        </codelist-item>
+        <codelist-item>
+            <code>XI-IATI-BBDN</code>
+            <name>
+                <narrative>Bangladesh Business &amp; Disability Network</narrative>
+            </name>
+            <description>
+                <narrative>The Bangladesh Business and Disability Network (BBDN) is a voluntary group of representatives from business, industry, employers’ organizations and selected non-governmental and disabled peoples’ organizations. BBDN has a primary purpose of facilitating disability and work place diversity in Bangladesh from the perspective of the business and human rights cases.</narrative>
+            </description>
+            <url>https://www.bbdn.com.bd/</url>
         </codelist-item>
         <codelist-item>
             <code>XI-IATI-EBRD</code>
@@ -165,6 +185,16 @@
             <url>http://ec.europa.eu/echo/</url>
         </codelist-item>
         <codelist-item>
+            <code>XI-IATI-ESFD</code>
+            <name>
+                <narrative>Economic and Social Fund for Development</narrative>
+            </name>
+            <description>
+                <narrative>The Economic and Social Fund for Development (ESFD) is a governmental body dedicated to alleviate poverty in Lebanon through the creation of employment opportunities and through the improvement of living conditions in disadvantaged communities.</narrative>
+            </description>
+            <url>http://www.esfd.cdr.gov.lb/</url>
+        </codelist-item>
+        <codelist-item>
             <code>XI-IATI-EC_FPI</code>
             <name>
                 <narrative>European Commission – Service for Foreign Policy Instruments</narrative>
@@ -205,6 +235,16 @@
             <url>https://www.fiabel.be/nl</url>
         </codelist-item>
         <codelist-item>
+            <code>XI-IATI-GREDO</code>
+            <name>
+                <narrative>Gargaar Relief and Development Organization</narrative>
+            </name>
+            <description>
+                <narrative>GREDO is a national NGO that is based in Baidoa which is the capital city of South West Administration of Somalia. It exists to support and reach the most affected grass-root communities in those regions and in Somalia at large. Our support focuses on Emergency and Development programs with a key thematic sectors of Integrated Health, Nutrition and Wash, Education and FSL.</narrative>
+            </description>
+            <url>https://www.gredosom.org/</url>
+        </codelist-item>
+        <codelist-item>
             <code>XI-IATI-IADB</code>
             <name>
                 <narrative>Inter-American Development Bank</narrative>
@@ -233,6 +273,16 @@
                 <narrative>Since 2008, the International Climate Initiative (IKI) of the Federal Ministry for the Environment, Nature Conservation, Building and Nuclear Safety (BMUB) has been financing climate and biodiversity projects in developing and newly industrialising countries, as well as in countries in transition.</narrative>
             </description>
             <url>https://www.international-climate-initiative.com/</url>
+        </codelist-item>
+        <codelist-item>
+            <code>XI-IATI-KHF</code>
+            <name>
+                <narrative>The King Hussein Foundation (KHF)</narrative>
+            </name>
+            <description>
+                <narrative>Their mission is to build upon King Hussein’s lifelong commitment to peace, sustainable community development and cross-cultural understanding through national and regional programs that promote education and leadership, economic empowerment and participatory decision-making.</narrative>
+            </description>
+            <url>http://www.kinghusseinfoundation.org/</url>
         </codelist-item>
         <codelist-item>
             <code>XI-IATI-LPI</code>
@@ -285,6 +335,26 @@
             <url>https://www.facebook.com/SomaliGenderJustice/</url>
         </codelist-item>
         <codelist-item>
+            <code>XI-IATI-SWSC</code>
+            <name>
+                <narrative>Somali Women Study Centre</narrative>
+            </name>
+            <description>
+                <narrative>SWSC is a women led NGO, founded in 2011 and based in Mogadishu and Kismayo, Somalia. SWSC seeks to achieve gender equality and social inclusion by empowering Somali women to exert their agency and improve their socio- economic status through strengthening their leadership, mentoring, capacity building, advocacy, and research to enable them articulate their specific needs in post- conflict Somalia.</narrative>
+            </description>
+            <url>https://www.somaliwomenstudiescentre.org/</url>
+        </codelist-item>
+        <codelist-item>
+            <code>XI-IATI-UCES</code>
+            <name>
+                <narrative>Umbrella for Community Education in Somalia</narrative>
+            </name>
+            <description>
+                <narrative>UCES is a national NGO that exists to work for advancement of Somalia Education by delivering formal and non-formal, alternative Education system to improve the knowledge of the Community through active advocacy and networking to deliver quality Education.</narrative>
+            </description>
+            <url>www.UCES.org</url>
+        </codelist-item>
+        <codelist-item>
             <code>XI-IATI-UDC</code>
             <name>
                 <narrative>United Darfur Committees</narrative>
@@ -304,6 +374,16 @@
             </description>
             <url>https://undg.org/</url>
         </codelist-item>
+        <codelist-item>
+            <code>XI-IATI-WARDI</code>
+            <name>
+                <narrative>Wardi Relief and Development Initiative</narrative>
+            </name>
+            <description>
+                <narrative>WARDI is a national NGO that exists to collaborate and provide assistance in all relevant sectors to the Somali communities. The key thematic intervention areas are Emergency relief, Food security and livelihood, Wash, Health and Nutrition, Education and Peace building and governance.</narrative>
+            </description>
+            <url>https://wardirelief.org/</url>
+        </codelist-item>
         <codelist-item activation-date="2016-12-15">
             <code>XI-IATI-WAI</code>
             <name>
@@ -313,6 +393,26 @@
                 <narrative>The WASH Alliance International is a consortium of member organisations in the Netherlands and partner organisations worldwide, working on sustainable WASH for everyone.</narrative>
             </description>
             <url>http://wash-alliance.org/</url>
+        </codelist-item>
+        <codelist-item activation-date="2020-05-12">
+            <code>XI-IATI-WBTF</code>
+            <name>
+                <narrative>World Bank Trust Funds (WBTF)</narrative>
+            </name>
+            <description>
+                <narrative>A trust fund (TF) is a financing arrangement established with contributions from one or more external development partner(s)/partners, and in some cases, from the World Bank Group, to support development-related activities. The World Bank acts as a trustee/administrator for development partners (donors) funds and implements the activities financed through trust funds in accordance with the signed agreements with donors. As part of fiduciary obligations, the World Bank as Trustee/administrator of trust funds maintains the records for trust funds activities distinct and separate from the activities of IBRD and IDA. The Bank also provides periodic report on the financial situation and results of the individual trust funds to donors.</narrative>
+            </description>
+            <url>https://www.worldbank.org/en/publication/trust-fund-annual-report-2019</url>
+        </codelist-item>
+        <codelist-item>
+            <code>XI-IATI-WVDRC</code>
+            <name>
+                <narrative>World Vision DRC</narrative>
+            </name>
+            <description>
+                <narrative>Our teams have been working in the DRC since 1984. Today, we are working to contribute to the measurable and sustainable improvement of well-being for 5,311,208 children and their communities through transformational development and humanitarian relief programmes focused on: health and nutrition, education, water and sanitation, protecting children, livelihoods and resilience, food aid, psychosocial support and the reintegration if displaced people.</narrative>
+            </description>
+            <url>https://www.wvi.org/congo-drc/about-us</url>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/lib/schemata/non-embedded-codelist/Region.xml
+++ b/lib/schemata/non-embedded-codelist/Region.xml
@@ -44,7 +44,7 @@
                 <narrative xml:lang="fr">Afrique, régional</narrative>
             </name>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2020-05-04">
             <code>380</code>
             <name>
                 <narrative>West Indies, regional</narrative>
@@ -126,6 +126,69 @@
             <name>
                 <narrative>Developing countries, unspecified</narrative>
                 <narrative xml:lang="fr">Pays en développement, non spécifié</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1027</code>
+            <name>
+                <narrative>Eastern Africa, regional</narrative>
+                <narrative xml:lang="fr">Afrique de l'est, régional</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1028</code>
+            <name>
+                <narrative>Middle Africa, regional</narrative>
+                <narrative xml:lang="fr">Afrique centrale, régional</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1029</code>
+            <name>
+                <narrative>Southern Africa, regional</narrative>
+                <narrative xml:lang="fr">Afrique australe, régional</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1030</code>
+            <name>
+                <narrative>Western Africa, regional</narrative>
+                <narrative xml:lang="fr">Afrique occidentale, régional</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1031</code>
+            <name>
+                <narrative>Caribbean, regional</narrative>
+                <narrative xml:lang="fr">Caraïbes, régional</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1032</code>
+            <name>
+                <narrative>Central America, regional</narrative>
+                <narrative xml:lang="fr">Amérique centrale, régional</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1033</code>
+            <name>
+                <narrative>Melanesia, regional</narrative>
+                <narrative xml:lang="fr">Mélanésie, régional</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1034</code>
+            <name>
+                <narrative>Micronesia, regional</narrative>
+                <narrative xml:lang="fr">Micronésie, régional</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-05-04">
+            <code>1035</code>
+            <name>
+                <narrative>Polynesia, regional</narrative>
+                <narrative xml:lang="fr">Polynésie, régional</narrative>
             </name>
         </codelist-item>
     </codelist-items>

--- a/lib/schemata/non-embedded-codelist/Sector.xml
+++ b/lib/schemata/non-embedded-codelist/Sector.xml
@@ -436,8 +436,8 @@
                 <narrative xml:lang="fr">Politique/programmes en matière de population et gestion administrative</narrative>
             </name>
             <description>
-                <narrative>Population/development policies; census work, vital registration; demographic research/analysis; reproductive health research; unspecified population activities. (Use purpose code 15190 for data on migration and refugees.)</narrative>
-                <narrative xml:lang="fr">Politique en matière de population et de développement ; recensement, enregistrement des naissances/décès ; données sur la migration ; recherche et analyse démographiques ; recherche en santé et fertilité ; activités de population non spécifiées. (Utilise le code 15190 pour les données sur la migration et les refugiés).</narrative>
+                <narrative>Population/development policies; demographic research/analysis; reproductive health research; unspecified population activities. (Use purpose code 15190 for data on migration and refugees. Use code 13096 for census work, vital registration and migration data collection.)</narrative>
+                <narrative xml:lang="fr">Politique en matière de population et de développement ; données sur la migration ; recherche et analyse démographiques ; recherche en santé et fertilité ; activités de population non spécifiées. (Utiliser le code 15190 pour les données sur la migration et les refugiés. Utiliser le code 13096 pour recensement, enregistrement des naissances/décès.)</narrative>
             </description>
             <category>130</category>
         </codelist-item>
@@ -486,6 +486,18 @@
             <description>
                 <narrative>Education and training of health staff for population and reproductive health care services.</narrative>
                 <narrative xml:lang="fr">Éducation et formation du personnel de santé pour les services de population ainsi que les soins en matière de santé et fertilité.</narrative>
+            </description>
+            <category>130</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>13096</code>
+            <name>
+                <narrative>Population statistics and data</narrative>
+                <narrative xml:lang="fr">Statistiques et données démographiques</narrative>
+            </name>
+            <description>
+                <narrative>Collection, production, management and dissemination of statistics and data related to Population and Reproductive Health. Includes census work, vital registration, migration data collection, demographic data, etc.</narrative>
+                <narrative xml:lang="fr">Collecte, production, gestion et diffusion de statistiques et de données relatives à la population et à la santé génésique. Comprend les travaux de recensement, l'état civil, la collecte de données sur la migration, les données démographiques, etc.</narrative>
             </description>
             <category>130</category>
         </codelist-item>
@@ -729,7 +741,7 @@
             </description>
             <category>151</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2010-12-31">
             <code>15120</code>
             <name>
                 <narrative>Public sector financial management</narrative>
@@ -854,8 +866,8 @@
                 <narrative xml:lang="fr">Développement des services légaux et judiciaires</narrative>
             </name>
             <description>
-                <narrative>Support to institutions, systems and procedures of the justice sector, both formal and informal; support to ministries of justice, the interior and home affairs; judges and courts; legal drafting services; bar and lawyers associations; professional legal education; maintenance of law and order and public safety; border management; law enforcement agencies, police, prisons and their supervision; ombudsmen; alternative dispute resolution, arbitration and mediation; legal aid and counsel; traditional, indigenous and paralegal practices that fall outside the formal legal system. Measures that support the improvement of legal frameworks, constitutions, laws and regulations; legislative and constitutional drafting and review; legal reform; integration of formal and informal systems of law. Public legal education; dissemination of information on entitlements and remedies for injustice; awareness campaigns. (Use codes 152xx for activities that are primarily aimed at supporting security system reform or undertaken in connection with post-conflict and peace building activities. Use code 15130 for capacity building in border management related to migration.)</narrative>
-                <narrative xml:lang="fr">Soutien aux institutions, systèmes et procédures du secteur de la justice, aussi bien officiels que non officiels ; soutien aux ministères de la justice et de l’intérieur ; juges et tribunaux ; services de rédaction des actes juridiques ; associations d’avocats et de juristes ; formation juridique professionnelle ; maintien de l’ordre et de la sécurité publique ; gestion des frontières ; organismes chargés de faire respecter la loi, police, prisons et leur supervision ; médiateurs ; mécanismes alternatifs de règlement des conflits, d’arbitrage et de médiation ; aide et conseil juridiques ; pratiques traditionnelles, indigènes et paralégales ne faisant pas partie du système juridique officiel. Mesures à l’appui de l’amélioration des cadres juridiques, constitutions, lois  et  réglementations ; rédaction et révision de textes législatifs et constitutionnels ; réforme juridique ; intégration des systèmes légaux officiels et non officiels. Éducation juridique ; diffusion d’informations sur les droits et les voies de recours en cas d’injustice ; campagnes de sensibilisation. (Utiliser les codes 152xx pour les activités ayant principalement pour objet de soutenir la réforme des systèmes de sécurité ou entreprises en liaison avec des activités de maintien de la paix à l’issue d’un conflit.)</narrative>
+                <narrative>Support to institutions, systems and procedures of the justice sector, both formal and informal; support to ministries of justice, the interior and home affairs; judges and courts; legal drafting services; bar and lawyers associations; professional legal education; maintenance of law and order and public safety; border management; law enforcement agencies, police, prisons and their supervision; ombudsmen; alternative dispute resolution, arbitration and mediation; legal aid and counsel; traditional, indigenous and paralegal practices that fall outside the formal legal system. Measures that support the improvement of legal frameworks, constitutions, laws and regulations; legislative and constitutional drafting and review; legal reform; integration of formal and informal systems of law. Public legal education; dissemination of information on entitlements and remedies for injustice; awareness campaigns. (Use codes 152xx for activities that are primarily aimed at supporting security system reform or undertaken in connection with post-conflict and peace building activities. Use code 15190 for capacity building in border management related to migration.)</narrative>
+                <narrative xml:lang="fr">Soutien aux institutions, systèmes et procédures du secteur de la justice, aussi bien officiels que non officiels ; soutien aux ministères de la justice et de l’intérieur ; juges et tribunaux ; services de rédaction des actes juridiques ; associations d’avocats et de juristes ; formation juridique professionnelle ; maintien de l’ordre et de la sécurité publique ; gestion des frontières ; organismes chargés de faire respecter la loi, police, prisons et leur supervision ; médiateurs ; mécanismes alternatifs de règlement des conflits, d’arbitrage et de médiation ; aide et conseil juridiques ; pratiques traditionnelles, indigènes et paralégales ne faisant pas partie du système juridique officiel. Mesures à l’appui de l’amélioration des cadres juridiques, constitutions, lois  et  réglementations ; rédaction et révision de textes législatifs et constitutionnels ; réforme juridique ; intégration des systèmes légaux officiels et non officiels. Éducation juridique ; diffusion d’informations sur les droits et les voies de recours en cas d’injustice ; campagnes de sensibilisation. (Utiliser les codes 152xx pour les activités ayant principalement pour objet de soutenir la réforme des systèmes de sécurité ou entreprises en liaison avec des activités de maintien de la paix à l’issue d’un conflit. Utiliser le code 15190 pour le renforcement des capacités dans le domaine de la surveillance des frontières en relation avec les migrations)</narrative>
             </description>
             <category>151</category>
         </codelist-item>
@@ -943,7 +955,7 @@
             </description>
             <category>151</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2010-12-31">
             <code>15140</code>
             <name>
                 <narrative>Government administration</narrative>
@@ -1085,7 +1097,7 @@
             </description>
             <category>151</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2010-12-31">
             <code>15161</code>
             <name>
                 <narrative>Elections</narrative>
@@ -1095,7 +1107,7 @@
             </description>
             <category>151</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2010-12-31">
             <code>15162</code>
             <name>
                 <narrative>Human rights</narrative>
@@ -1105,7 +1117,7 @@
             </description>
             <category>151</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2010-12-31">
             <code>15163</code>
             <name>
                 <narrative>Free flow of information</narrative>
@@ -1115,7 +1127,7 @@
             </description>
             <category>151</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2010-12-31">
             <code>15164</code>
             <name>
                 <narrative>Women's equality organisations and institutions</narrative>
@@ -1128,12 +1140,12 @@
         <codelist-item status="active">
             <code>15170</code>
             <name>
-                <narrative>Women's equality organisations and institutions</narrative>
-                <narrative xml:lang="fr">Organisations et institutions pour l’égalité des femmes</narrative>
+                <narrative>Women’s rights organisations and movements, and government institutions</narrative>
+                <narrative xml:lang="fr">Organisations et mouvements de défense des droits des femmes et institutions gouvernementales</narrative>
             </name>
             <description>
-                <narrative>Support for institutions and organisations (governmental and non-governmental) working for gender equality and women’s empowerment.</narrative>
-                <narrative xml:lang="fr">Soutien aux institutions et organisations (gouvernementales et non gouvernementales) qui œuvrent pour l’égalité homme-femme et l’autonomisation des femmes.</narrative>
+                <narrative>Support for feminist, women-led and women’s rights organisations and movements, and institutions (governmental and non-govermental) at all levels to enhance their effectiveness, influence and substainability (activities and core-funding). These organisations exist to bring about transformative change for gender equality and/or the rights of women and girls in developing countries. Their activities include agenda-setting, advocacy, policy dialogue, capacity development, awareness raising and prevention, service provision, conflict-prevention and peacebuilding, research, organising, and alliance and network building</narrative>
+                <narrative xml:lang="fr">Appui aux organisations et mouvements féministes, dirigés par des femmes et de défense des droits des femmes, ainsi qu'aux institutions (gouvernementales et non gouvernementales) à tous les niveaux pour améliorer leur efficacité, leur influence et leur durabilité (activités et financement de base). Ces organisations existent pour apporter un changement transformateur pour l'égalité des sexes et / ou les droits des femmes et des filles dans les pays en développement. Leurs activités comprennent la définition de l'agenda, le plaidoyer, le dialogue politique, le renforcement des capacités, la sensibilisation et la prévention, la prestation de services, la prévention des conflits et la consolidation de la paix, la recherche, l'organisation et la création d'alliances et de réseaux.</narrative>
             </description>
             <category>151</category>
         </codelist-item>
@@ -1170,6 +1182,18 @@
             <description>
                 <narrative>Assistance to developing countries that facilitates the orderly, safe, regular and responsible migration and mobility of people. This includes:• Capacity building in migration and mobility policy, analysis, planning and management. This includes support to facilitate safe and regular migration and address irregular migration, engagement with diaspora and programmes enhancing the development impact of remittances and/or their use for developmental projects in developing countries.• Measures to improve migrant labour recruitment systems in developing countries.• Capacity building for strategy and policy development as well as legal and judicial development (including border management) in developing countries. This includes support to address and reduce vulnerabilities in migration, and strengthen the transnational response to smuggling of migrants and preventing and combating trafficking in human beings.• Support to effective strategies to ensure international protection and the right to asylum.• Support to effective strategies to ensure access to justice and assistance for displaced persons.• Assistance to migrants for their safe, dignified, informed and voluntary return to their country of origin (covers only returns from another developing country; assistance to forced returns is excluded from ODA).• Assistance to migrants for their sustainable reintegration in their country of origin (use code 93010 for pre-departure assistance provided in donor countries in the context of voluntary returns). Activities that pursue first and foremost providers’ interest are excluded from ODA. Activities addressing the root causes of forced displacement and irregular migration should not be coded here, but under their relevant sector of intervention. In addition, use code 15136 for support to countries' authorities for immigration affairs and services (optional), code 24050 for programmes aiming at reducing the sending costs of remittances, code 72010 for humanitarian aspects of assistance to refugees and internally displaced persons (IDPs) such as delivery of emergency services and humanitarian protection. Use code 93010 when expenditure is for the temporary sustenance of refugees in the donor country, including for their voluntary return and for their reintegration when support is provided in a donor country in connection with the return from that donor country (i.e. pre-departure assistance), or voluntary resettlement in a third developed country.</narrative>
                 <narrative xml:lang="fr">Aide apportée aux pays en développement dans le but de favoriser des migrations et une mobilité des personnes qui soient ordonnées, sûres, régulières et responsables. Elle recouvre : - le renforcement des capacités concernant la politique, l’analyse, la planification et la gestion dans le domaine des migrations et de la mobilité. Celui-ci comprend le soutien visant à favoriser des migrations sûres et régulières et à remédier aux migrations irrégulières, la coopération avec la diaspora et les programmes destinés à renforcer l’impact des envois de fonds des émigrés sur le développement et/ou l’utilisation de ces fonds pour financer des projets utiles au développement dans les pays en développement ; - les mesures visant à améliorer les systèmes de recrutement de la main-d’œuvre migrante dans les pays en développement ; - le renforcement des capacités en matière d’élaboration de stratégies et de politiques, ainsi que pour le développement des services juridiques et judiciaires (y compris la gestion des frontières) dans les pays en développement. Il comprend le soutien apporté pour la prise en main et la réduction des facteurs de vulnérabilité existant en situation de migration, et pour le renforcement des efforts transnationaux visant à lutter contre le trafic de migrants, ainsi qu’à prévenir et combattre le trafic d’êtres humains ; - le soutien à la mise en place de stratégies efficaces pour garantir la protection internationale et le droit à l’asile ; - le soutien à la mise en place de stratégies efficaces pour assurer aux personnes déplacées l’accès à la justice et à une aide ; - l’aide dispensée aux migrants pour leur permettre de rentrer dans leur pays d’origine en toute sécurité, dans la dignité, en pleine connaissance de cause et de façon volontaire (ne sont couverts que les retours effectués à partir d’un autre pays en développement ; l’aide au titre des retours forcés est exclue de l’APD) ; - l’aide dispensée aux migrants en vue de leur réintégration durable dans leur pays d’origine (utiliser le code 93010 pour l’aide apportée dans les pays donneurs préalablement au départ, dans le contexte de retours volontaires). Les activités visant à servir avant tout les intérêts des fournisseurs sont exclues de l’APD. Les activités visant à remédier aux causes profondes des déplacements forcés et des migrations irrégulières ne doivent pas être classées sous ce code, mais dans le secteur d’intervention correspondant. De plus, il faut utiliser le code 15136 pour le soutien dispensé aux autorités des pays aux fins des questions et des services relatifs à l’immigration (facultatif), le code 24050 pour les dispositifs visant à réduire le coût des envois de fonds des émigrés, le code 72010 pour les aspects humanitaires de l’aide apportée aux réfugiés et aux personnes déplacées à l’intérieur de leur propre pays, comme la fourniture de services d’urgence et la protection humanitaire. Le code 93010 doit être employé lorsque les dépenses sont destinées à l’entretien temporaire des réfugiés dans le pays donneur, notamment dans le cas de leur retour volontaire et de leur réintégration lorsque ce soutien est fourni dans le pays donneur en liaison avec le retour à partir de ce pays (aide préalable au départ) ou de leur réinstallation volontaire dans un pays développé tiers.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>15196</code>
+            <name>
+                <narrative>Government and civil society statistics and data</narrative>
+                <narrative xml:lang="fr">Statistiques et données du gouvernement et de la société civile</narrative>
+            </name>
+            <description>
+                <narrative>Collection, production, management and dissemination of statistics and data related to Government &amp; Civil Society. Includes macroeconomic statistics, government finance, fiscal and public sector statistics, support to development of administrative data infrastructure, civil society surveys.</narrative>
+                <narrative xml:lang="fr">Collecte, production, gestion et diffusion de statistiques et de données relatives au gouvernement et à la société civile. Comprend les statistiques macroéconomiques, les finances publiques, les statistiques fiscales et du secteur public, le soutien au développement de l'infrastructure de données administratives, les enquêtes de la société civile.</narrative>
             </description>
             <category>151</category>
         </codelist-item>
@@ -1384,8 +1408,8 @@
                 <narrative xml:lang="fr">Renforcement des capacités statistiques</narrative>
             </name>
             <description>
-                <narrative>Both in national statistical offices and any other government ministries.</narrative>
-                <narrative xml:lang="fr">Dans les offices statistiques nationaux et les autres ministères concernés.</narrative>
+                <narrative>All statistical activities, such as data collection, processing, dissemination and analysis; support to development and management of official statistics including demographic, social, economic, environmental and multi-sectoral statistics; statistical quality frameworks; development of human and technological resources for statistics, investments in data innovation. Activities related to data and statistics in the sectors 120, 130 or 150 should preferably be coded under the voluntary purpose codes 12196, 13096 and 15196. Activities with the sole purpose of monitoring development co-operation activities, including if performed by third parties, should be coded under 91010 (Administrative costs).</narrative>
+                <narrative xml:lang="fr">Toutes les activités statistiques, telles que la collecte, le traitement, la diffusion et l'analyse des données; appui au développement et à la gestion des statistiques officielles, y compris les statistiques démographiques, sociales, économiques, environnementales et multisectorielles; cadres de qualité des statistiques; développement des ressources humaines et technologiques pour la statistique, investissements dans l'innovation des données. Les activités liées aux données et aux statistiques dans les secteurs 120, 130 ou 150 devraient de préférence être codées sous les codes volontaire 12196, 13096 et 15196. Les activités ayant pour seul objectif de surveiller les activités de coopération au développement, y compris si elles sont menées par des tiers, devraient être codé sous 91010 (Frais administratifs).</narrative>
             </description>
             <category>160</category>
         </codelist-item>
@@ -1713,7 +1737,7 @@
             </description>
             <category>220</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23010</code>
             <name>
                 <narrative>Energy policy and administrative management</narrative>
@@ -1723,7 +1747,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23020</code>
             <name>
                 <narrative>Power generation/non-renewable sources</narrative>
@@ -1733,7 +1757,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23030</code>
             <name>
                 <narrative>Power generation/renewable sources</narrative>
@@ -1743,7 +1767,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23040</code>
             <name>
                 <narrative>Electrical transmission/ distribution</narrative>
@@ -1753,7 +1777,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23050</code>
             <name>
                 <narrative>Gas distribution</narrative>
@@ -1763,7 +1787,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23061</code>
             <name>
                 <narrative>Oil-fired power plants</narrative>
@@ -1773,7 +1797,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23062</code>
             <name>
                 <narrative>Gas-fired power plants</narrative>
@@ -1783,7 +1807,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23063</code>
             <name>
                 <narrative>Coal-fired power plants</narrative>
@@ -1793,7 +1817,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23064</code>
             <name>
                 <narrative>Nuclear power plants</narrative>
@@ -1803,7 +1827,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23065</code>
             <name>
                 <narrative>Hydro-electric power plants</narrative>
@@ -1813,7 +1837,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23066</code>
             <name>
                 <narrative>Geothermal energy</narrative>
@@ -1823,7 +1847,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23067</code>
             <name>
                 <narrative>Solar energy</narrative>
@@ -1833,7 +1857,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23068</code>
             <name>
                 <narrative>Wind power</narrative>
@@ -1843,7 +1867,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23069</code>
             <name>
                 <narrative>Ocean power</narrative>
@@ -1853,7 +1877,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23070</code>
             <name>
                 <narrative>Biomass</narrative>
@@ -1863,7 +1887,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23081</code>
             <name>
                 <narrative>Energy education/training</narrative>
@@ -1873,7 +1897,7 @@
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23082</code>
             <name>
                 <narrative>Energy research</narrative>
@@ -1890,8 +1914,8 @@
                 <narrative xml:lang="fr">Politique énergétique et gestion administrative</narrative>
             </name>
             <description>
-                <narrative>Energy sector policy, planning; aid to energy ministries; institution capacity building and advice; unspecified energy activities.</narrative>
-                <narrative xml:lang="fr">Politique et planification du secteur de l’énergie ; aide aux ministères de l’énergie ; conseils et renforcement des capacités institutionnelles ; activités non précisées.</narrative>
+                <narrative>Energy sector policy, planning; aid to energy ministries and other governmental or nongovernmental institutions for activities related to the SDG7; institution capacity building and advice; tariffs, market building, unspecified energy activities; energy activities for which a more specific code cannot be assigned.</narrative>
+                <narrative xml:lang="fr">Politique et planification du secteur de l’énergie ; aide aux ministères de l’énergie et autres institutions gouvernementales et non-gouvernementales pour les activités liées à l'ODD7 ; conseil et renforcement des capacités institutionnelles ; tarifs, construction du marché ; activités non précisées ou ne pouvant pas recevoir de code spécifique.</narrative>
             </description>
             <category>231</category>
         </codelist-item>
@@ -1950,8 +1974,8 @@
                 <narrative xml:lang="fr">Économies d'énergie et efficacité du côté de la demande</narrative>
             </name>
             <description>
-                <narrative>All projects in support of energy demand reduction, e.g. building and industry upgrades, smart grids, metering and tariffs. Also includes efficient cook-stoves and biogas projects.</narrative>
-                <narrative xml:lang="fr">Tous les projets visant la réduction de la demande d’énergie, par exemple : modernisation des bâtiments et des industries, réseaux intelligents, compteurs et tarifs. Comprend également les cuisinières efficaces et les projets de biogaz.</narrative>
+                <narrative>Support for energy demand reduction, e.g. building and industry upgrades, smart grids, metering and tariffs. For clean cooking appliances use code 32174.</narrative>
+                <narrative xml:lang="fr">Soutien à la réduction de la demande énergétique, par exemple : modernisation des bâtiments et des industries, réseaux intelligents, compteurs et tarifs. Pour l'usage des cuisinières efficaces utiliser le code 32174</narrative>
             </description>
             <category>231</category>
         </codelist-item>
@@ -1982,12 +2006,36 @@
         <codelist-item status="active">
             <code>23230</code>
             <name>
-                <narrative>Solar energy</narrative>
-                <narrative xml:lang="fr">Énergie solaire</narrative>
+                <narrative>Solar energy for centralised grids</narrative>
+                <narrative xml:lang="fr">Energie solaire pour réseaux centralisés</narrative>
             </name>
             <description>
-                <narrative>Including photo-voltaic cells, solar thermal applications and solar heating.</narrative>
-                <narrative xml:lang="fr">Solaire photovoltaïque, thermodynamique, chauffage solaire.</narrative>
+                <narrative>Including photo-voltaic cells, concentrated solar power systems connected to the main grid and net-metered decentralised solutions.</narrative>
+                <narrative xml:lang="fr">Comprend les panneaux photovoltaïques, les systèmes d'énergie solaire à concentration connectés au réseau principal ainsi que les solutions décentralisées équipées de compteurs à mesure nette.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>23231</code>
+            <name>
+                <narrative>Solar energy for isolated grids and standalone systems</narrative>
+                <narrative xml:lang="fr">Energie solaire pour réseaux isolés et systèmes autonomes</narrative>
+            </name>
+            <description>
+                <narrative>Solar power generation for isolated mini-grids, solar home systems (including integrated wiring and related appliances), solar lanterns distribution and commercialisation. This code refers to the power generation component only.</narrative>
+                <narrative xml:lang="fr">Production électrique solaire pour réseau isolé et systèmes autonomes, systèmes solaires individuels (y compris câblage intégré et appareils liés), distribution et commercialisation de lampes solaires. Ce code traite exclusivement de production d'énergie.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>23232</code>
+            <name>
+                <narrative>Solar energy - thermal applications</narrative>
+                <narrative xml:lang="fr">Energie solaire - usage thermique</narrative>
+            </name>
+            <description>
+                <narrative>Solar solutions for indoor space and water heating (except for solar cook stoves 32174).</narrative>
+                <narrative xml:lang="fr">Solutions solaires pour espaces intérieurs et chauffage de l'eau (sauf fours solaires 32174)</narrative>
             </description>
             <category>232</category>
         </codelist-item>
@@ -2034,7 +2082,7 @@
                 <narrative xml:lang="fr">Centrales à biocombustibles</narrative>
             </name>
             <description>
-                <narrative>Use of solids and liquids produced from biomass for direct power generation. Also includes biogases from anaerobic fermentation (e.g. landfill gas, sewage sludge gas, fermentation of energy crops and manure) and thermal processes (also known as syngas); waste-fired power plants making use of biodegradable municipal waste (household waste and waste from companies and public services that resembles household waste, collected at installations specifically designed for their disposal with recovery of combustible liquids, gases or heat). See code 23360 for non- renewable waste-fired power plants.</narrative>
+                <narrative>Use of solids and liquids produced from biomass for direct power generation. Also includes biogases from anaerobic fermentation (e.g. landfill gas, sewage sludge gas, fermentation of energy crops and manure) and thermal processes (also known as syngas); waste-fired power plants making use of biodegradable municipal waste (household waste and waste from companies and public services that resembles household waste, collected at installations specifically designed for their disposal with recovery of combustible liquids, gases or heat). See code 23360 for non-renewable waste-fired power plants.</narrative>
                 <narrative xml:lang="fr">Utilisation de matières solides et liquides issues de la biomasse pour la production directe d’électricité. Comprend également les biogaz produits par fermentation anaérobie (ex. : gaz de décharge, gaz issus des boues d’épuration, fermentation de végétaux des cultures énergétiques et de déjections animales) et par traitements thermiques (également connus sous l’appellation de gaz de synthèse) ; centrales brûlant des déchets municipaux biodégradables (déchets ménagers et déchets du tertiaire assimilables à des déchets ménagers, collectés dans des installations spécifiquement conçues pour leur élimination et leur récupération sous forme de liquides ou de gaz combustibles ou de chaleur). Voir code 23360 pour la production d’électricité, déchets non renouvelables.</narrative>
             </description>
             <category>232</category>
@@ -2082,8 +2130,8 @@
                 <narrative xml:lang="fr">Centrales au gaz naturel</narrative>
             </name>
             <description>
-                <narrative>Electric power plants that are fuelled by natural gas.</narrative>
-                <narrative xml:lang="fr">Centrales thermiques brûlant du gaz naturel.</narrative>
+                <narrative>Electric power plants that are fuelled by natural gas; related feed-in infrastructure (LNG terminals, gasifiers, pipelines to feed the plant).</narrative>
+                <narrative xml:lang="fr">Centrales thermiques fonctionnant au gaz naturel. Infrastructures d'alimention (terminaux GNL, gazéifieurs, gazoducs d'alimentation de la centrale)</narrative>
             </description>
             <category>233</category>
         </codelist-item>
@@ -2126,12 +2174,12 @@
         <codelist-item status="active">
             <code>23510</code>
             <name>
-                <narrative>Nuclear energy electric power plants</narrative>
+                <narrative>Nuclear energy electric power plants and nuclear safety</narrative>
                 <narrative xml:lang="fr">Centrales nucléaires</narrative>
             </name>
             <description>
-                <narrative>Including nuclear safety.</narrative>
-                <narrative xml:lang="fr">Dont sûreté nucléaire.</narrative>
+                <narrative>See note regarding ODA eligibility of nuclear energy.</narrative>
+                <narrative xml:lang="fr">Dont sûreté nucléaire. Voir la note sur l'éligibilité à l'APD de l'énergie nucléaire</narrative>
             </description>
             <category>235</category>
         </codelist-item>
@@ -2162,24 +2210,60 @@
         <codelist-item status="active">
             <code>23630</code>
             <name>
-                <narrative>Electric power transmission and distribution</narrative>
-                <narrative xml:lang="fr">Transport et distribution d'électricité</narrative>
+                <narrative>Electric power transmission and distribution (centralised grids)</narrative>
+                <narrative xml:lang="fr">Transport et distribution d'électricité (réseaux centralisés)</narrative>
             </name>
             <description>
                 <narrative>Grid distribution from power source to end user; transmission lines. Also includes storage of energy to generate power (e.g. pumped hydro, batteries) and the extension of grid access, often to rural areas.</narrative>
-                <narrative xml:lang="fr">Distribution d’électricité par le réseau, de la source au consommateur final ; lignes de transport. Inclut également le stockage de l’énergie à des fins de production d’électricité (ex. : station de pompage, batteries) et l’extension de l’accès au réseau, souvent dans des zones rurales.</narrative>
+                <narrative xml:lang="fr">Réseau de distribution d’électricité de la source d'énergie au consommateur final ; lignes de transport. Inclut également le stockage de l’énergie à des fins de production d’électricité (ex. : station de pompage, batteries) et l’extension de l’accès au réseau, souvent dans des zones rurales.</narrative>
+            </description>
+            <category>236</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>23631</code>
+            <name>
+                <narrative>Electric power transmission and distribution (isolated mini-grids)</narrative>
+                <narrative xml:lang="fr">Transport et distribution d'électricité (petits réseaux isolés)</narrative>
+            </name>
+            <description>
+                <narrative>Includes village grids and other electricity distribution technologies to end users that are not connected to the main national grid. Also includes related electricity storage. This code refers to the network infrastructure only regardless of the power generation technologies.</narrative>
+                <narrative xml:lang="fr">Comprend les réseaux villageois et autres technologies de distribution d'électricité à destination des consommateurs finals non connectés au  réseau national principal. Inclut également le stockage d'électricité. Ce code traite exclusivement de l'infrastructure du réseau indépendamment de la technologie de production.</narrative>
             </description>
             <category>236</category>
         </codelist-item>
         <codelist-item status="active">
             <code>23640</code>
             <name>
-                <narrative>Gas distribution</narrative>
-                <narrative xml:lang="fr">Distribution du gaz</narrative>
+                <narrative>Retail gas distribution</narrative>
+                <narrative xml:lang="fr">Distribution au détail de gaz</narrative>
             </name>
             <description>
-                <narrative>Delivery for use by ultimate consumer.</narrative>
-                <narrative xml:lang="fr">Acheminement du gaz jusqu’au consommateur final.</narrative>
+                <narrative>Includes urban infrastructure for the delivery of urban gas and LPG cylinder production, distribution and refill. Excludes gas distribution for purposes of electricity generation (23340) and pipelines (32262).</narrative>
+                <narrative xml:lang="fr">Comprend l'infrastructure urbaine de livraison de gaz de ville et la production, distribution et recharge de bouteilles de GPL. Exclut l'acheminement de gaz à des fins de production électrique (23340) et les gazoducs (32262)</narrative>
+            </description>
+            <category>236</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>23641</code>
+            <name>
+                <narrative>Retail distribution of liquid or solid fossil fuels</narrative>
+                <narrative xml:lang="fr">Distribution au détail de carburants fossiles liquide ou solides</narrative>
+            </name>
+            <description>
+                <narrative/>
+                <narrative xml:lang="fr"/>
+            </description>
+            <category>236</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>23642</code>
+            <name>
+                <narrative>Electric mobility infrastructures</narrative>
+                <narrative xml:lang="fr">Infrastructures électriques à l'usage de la mobilité</narrative>
+            </name>
+            <description>
+                <narrative>Includes electricity or hydrogen recharging stations for private and public transport systems and related infrastructure (except for rail transport 21030).</narrative>
+                <narrative xml:lang="fr">Inclut les stations de recharge électrique ou à hydrogène pour les transports publics ou privés et infrastructures connexes (sauf transport ferrovaire 21030)</narrative>
             </description>
             <category>236</category>
         </codelist-item>
@@ -2550,8 +2634,8 @@
                 <narrative xml:lang="fr">Reboisement (bois de chauffage et charbon de bois)</narrative>
             </name>
             <description>
-                <narrative>Forestry development whose primary purpose is production of fuelwood and charcoal.</narrative>
-                <narrative xml:lang="fr">Développement sylvicole visant à la production de bois de chauffage et de charbon de bois.</narrative>
+                <narrative>Sustainable forestry development whose primary purpose is production of fuelwood and charcoal. Further transformation of biomass in biofuels is coded under 32173.</narrative>
+                <narrative xml:lang="fr">Développement sylvicole soutenable visant à la production de bois de chauffage et de charbon de bois. La transformation ultérieure de biomasse en biocarburants est codée 32173.</narrative>
             </description>
             <category>312</category>
         </codelist-item>
@@ -2774,12 +2858,12 @@
         <codelist-item status="active">
             <code>32167</code>
             <name>
-                <narrative>Energy manufacturing</narrative>
+                <narrative>Energy manufacturing (fossil fuels)</narrative>
                 <narrative xml:lang="fr">Fabrication d’énergie</narrative>
             </name>
             <description>
-                <narrative>Including gas liquefaction; petroleum refineries.</narrative>
-                <narrative xml:lang="fr">Y compris liquéfaction du gaz ; raffineries de pétrole.</narrative>
+                <narrative>Including gas liquefaction; petroleum refineries, wholesale distribution of fossil fuels. (Use 23640 for retail distribution of gas and 23641 for retail distribution of liquid or solid fossil fuels.)</narrative>
+                <narrative xml:lang="fr">Y compris liquéfaction du gaz ; raffineries de pétrole, distribution en gros de carburants fossiles. (Utiliser 23640 pour la distribution au détail de gaz et 23461 pour la distribution au détail de carburant fossiles liquides ou solides.)</narrative>
             </description>
             <category>321</category>
         </codelist-item>
@@ -2843,6 +2927,30 @@
             </description>
             <category>321</category>
         </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>32173</code>
+            <name>
+                <narrative>Modern biofuels manufacturing</narrative>
+                <narrative xml:lang="fr">Production de biocarburants modernes</narrative>
+            </name>
+            <description>
+                <narrative>Includes biogas, liquid biofuels and pellets for domestic and non-domestic use. Excludes raw fuelwood and charcoal (31261).</narrative>
+                <narrative xml:lang="fr">Comprend le biogaz, les biocarburant liquides et les pellets à usage domestique ou non. Exclut le bois de chauffe brut et le charbon de bois (32161)</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>32174</code>
+            <name>
+                <narrative>Clean cooking appliances manufacturing</narrative>
+                <narrative xml:lang="fr">Production d'appareils de cuisine propres</narrative>
+            </name>
+            <description>
+                <narrative>Includes manufacturing and distribution of efficient biomass cooking stoves, gasifiers, liquid biofuels stoves, solar stoves, gas and biogas stoves, electric stoves.</narrative>
+                <narrative xml:lang="fr">Comprend la fabrication et la distribution de fours efficaces à biomasse, gazéifieurs, fours à biocarburants liquides, fours solaires, fours à gaz et bio gaz fours électriques</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
         <codelist-item status="active">
             <code>32182</code>
             <name>
@@ -2894,11 +3002,11 @@
         <codelist-item status="active">
             <code>32262</code>
             <name>
-                <narrative>Oil and gas</narrative>
+                <narrative>Oil and gas (upstream)</narrative>
                 <narrative xml:lang="fr">Pétrole et gaz</narrative>
             </name>
             <description>
-                <narrative>Petroleum, natural gas, condensates, liquefied petroleum gas (LPG), liquefied natural gas (LNG);  including drilling and production, and oil and gas pipelines.</narrative>
+                <narrative>Petroleum, natural gas, condensates, liquefied petroleum gas (LPG), liquefied natural gas (LNG); including drilling and production, oil and gas pipelines.</narrative>
                 <narrative xml:lang="fr">Pétrole, gaz naturel, condensés , GPL (Gaz de pétrole liquéfié), GNL (Gaz naturel liquéfié); y compris derricks et plates-formes de forage, et oléoducs et gazoducs.</narrative>
             </description>
             <category>322</category>
@@ -3462,8 +3570,32 @@
                 <narrative xml:lang="fr">Assistance matérielle et services d’urgence</narrative>
             </name>
             <description>
-                <narrative>Shelter, water, sanitation, education, health services including supply of medicines and malnutrition management, and other nonfood relief items (including cash and voucher delivery modalities) for the benefit of crisisaffected people, including refugees and internally displaced people in developing countries, Includes assistance delivered by or coordinated by international civil protection units in the immediate aftermath of a disaster (in-kind assistance, deployment of specially-equipped teams, logistics and transportation, or assessment and coordination by experts sent to the field). Also includes measures to promote and protect the safety, well-being, dignity and integrity of crisis-affected people including refugees and internally displaced persons in developing countries. (Activities designed to protect the security of persons or properties through the use or display of force are not reportable as ODA.)</narrative>
-                <narrative xml:lang="fr">Abris, eau, assainissement, éducation, services de santé, y compris la fourniture de médicaments et la gestion de la malnutrition, et autres articles de secours non alimentaires (y compris les modalités de remise en espèces et de bons) au profit des personnes touchées par la crise, notamment des réfugiés et des personnes déplacées dans les pays en developement. Comprend l'assistance fournie ou coordonnée par les unités internationales de la protection civile immédiatement après une catastrophe (assistance en nature, déploiement d'équipes spécialement équipées, logistique et transport, ou évaluation et coordination d'experts envoyés sur le terrain). Comprend également des mesures visant à promouvoir et à protéger la sécurité, le bien-être, la dignité et l’intégrité des personnes touchées par la crise, y compris des réfugiés et des personnes déplacées dans les pays en développement. (Les activités conçues pour protéger la sécurité des personnes ou des biens en recourant à la force ou à l'aide de la force ne sont pas déclarables en tant qu'APD.)</narrative>
+                <narrative>Shelter, water, sanitation, education, health services including supply of medicines and malnutrition management, including medical nutrition management; supply of other nonfood relief items (including cash and voucher delivery modalities) for the benefit of crisisaffected people, including refugees and internally displaced people in developing countries, Includes assistance delivered by or coordinated by international civil protection units in the immediate aftermath of a disaster (in-kind assistance, deployment of specially-equipped teams, logistics and transportation, or assessment and coordination by experts sent to the field). Also includes measures to promote and protect the safety, well-being, dignity and integrity of crisis-affected people including refugees and internally displaced persons in developing countries. (Activities designed to protect the security of persons or properties through the use or display of force are not reportable as ODA.)</narrative>
+                <narrative xml:lang="fr">Abris, eau, assainissement, éducation, services de santé, y compris la fourniture de médicaments et la gestion de la malnutrition, y compris la gestion de la nutrition médicale;  fourniture d'autres articles de secours non alimentaires (y compris les modalités de remise en espèces et de bons) au profit des personnes touchées par la crise, notamment des réfugiés et des personnes déplacées dans les pays en developement. Comprend l'assistance fournie ou coordonnée par les unités internationales de la protection civile immédiatement après une catastrophe (assistance en nature, déploiement d'équipes spécialement équipées, logistique et transport, ou évaluation et coordination d'experts envoyés sur le terrain). Comprend également des mesures visant à promouvoir et à protéger la sécurité, le bien-être, la dignité et l’intégrité des personnes touchées par la crise, y compris des réfugiés et des personnes déplacées dans les pays en développement. (Les activités conçues pour protéger la sécurité des personnes ou des biens en recourant à la force ou à l'aide de la force ne sonpas déclarables en tant qu'APD.)</narrative>
+            </description>
+            <category>720</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>72011</code>
+            <name>
+                <narrative>Basic Health Care Services in Emergencies</narrative>
+                <narrative xml:lang="fr">Services de soins de santé de base dans les situations d'urgence</narrative>
+            </name>
+            <description>
+                <narrative>Provision of health services (basic health services, mental health, sexual and reproductive health), medical nutritional intervention (therapeutic feeding and medical interventions for treating malnutrition) and supply of medicines for the benefit of affected people. Excludes supplemental feeding (72040).</narrative>
+                <narrative xml:lang="fr">Prestation de services de santé (services de santé de base, santé mentale, santé sexuelle et génésique), intervention nutritionnelle médicale (alimentation thérapeutique et interventions médicales pour traiter la malnutrition) et fourniture de médicaments au profit des personnes touchées. Exclut l'alimentation complémentaire (72040).</narrative>
+            </description>
+            <category>720</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>72012</code>
+            <name>
+                <narrative>Education in emergencies</narrative>
+                <narrative xml:lang="fr">Education dans les situations d'urgence</narrative>
+            </name>
+            <description>
+                <narrative>Support for education facilities (including restoring pre-existing essential infrastructure and school facilities), teaching, training and learning materials (including digital technologies, as appropriate) and immediate access to quality basic and primary education (including formal and non-formal education), and secondary education (including vocational training and secondary level technical education) in emergencies for the benefit of affected children and youth, particularly targeting girls and women and refugees, life skills for youth and adults, and vocational training for youth and adults</narrative>
+                <narrative xml:lang="fr">Soutien aux établissements d'enseignement (y compris la restauration des infrastructures essentielles et des installations scolaires préexistantes), du matériel d'enseignement, de formation et d'apprentissage (y compris les technologies numériques, le cas échéant) et un accès immédiat à une éducation de base et primaire de qualité (y compris l'éducation formelle et non formelle), et l'enseignement secondaire (y compris la formation professionnelle et l'enseignement technique de niveau secondaire) dans les situations d'urgence au profit des enfants et des jeunes touchés, en ciblant en particulier les filles et les femmes et les réfugiés, les compétences de vie pour les jeunes et les adultes, et la formation professionnelle pour les jeunes et les adultes</narrative>
             </description>
             <category>720</category>
         </codelist-item>
@@ -3474,8 +3606,8 @@
                 <narrative xml:lang="fr">Assistance alimentaire d'urgence</narrative>
             </name>
             <description>
-                <narrative>Provision and distribution of food; cash and vouchers for the purchase of food; non-medical nutritional interventions for the benefit of crisis-affected people, including refugees and internally displaced people in developing countries in emergency situations. Includes logistical costs. Excludes non-emergency food assistance (52010), food security policy and administrative management (43071), household food programmes (43072) and medical nutrition interventions (therapeutic feeding) (72010).</narrative>
-                <narrative xml:lang="fr">Fourniture et distribution de nourriture; de l'argent et des bons pour l'achat de nourriture; interventions nutritionnelles non médicales au profit des personnes touchées par la crise, notamment des réfugiés et des personnes déplacées à l'intérieur de leur propre pays, dans des pays en développement en situation d'urgence. Comprend les coûts logistiques. Sont exclus l'assistance alimentaire non urgente (52010), la politique de sécurité alimentaire et la gestion administrative (43071), les programmes alimentaires des ménages (43072) et les interventions de nutrition médicale (alimentation thérapeutique) (72010).</narrative>
+                <narrative>Provision and distribution of food; cash and vouchers for the purchase of food; non-medical nutritional interventions for the benefit of crisis-affected people, including refugees and internally displaced people in developing countries in emergency situations. Includes logistical costs. Excludes non-emergency food assistance (52010), food security policy and administrative management (43071), household food programmes (43072) and medical nutrition interventions (therapeutic feeding) (72010 and 72011).</narrative>
+                <narrative xml:lang="fr">Fourniture et distribution de nourriture; de l'argent et des bons pour l'achat de nourriture; interventions nutritionnelles non médicales au profit des personnes touchées par la crise, notamment des réfugiés et des personnes déplacées à l'intérieur de leur propre pays, dans des pays en développement en situation d'urgence. Comprend les coûts logistiques. Sont exclus l'assistance alimentaire non urgente (52010), la politique de sécurité alimentaire et la gestion administrative (43071), les programmes alimentaires des ménages (43072) et les interventions de nutrition médicale (alimentation thérapeutique) (72010 et 72011).</narrative>
             </description>
             <category>720</category>
         </codelist-item>
@@ -3539,7 +3671,7 @@
             </description>
             <category>910</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2012-12-31">
             <code>92010</code>
             <name>
                 <narrative>Support to national NGOs</narrative>
@@ -3549,7 +3681,7 @@
             </description>
             <category>920</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2012-12-31">
             <code>92020</code>
             <name>
                 <narrative>Support to international NGOs</narrative>
@@ -3559,7 +3691,7 @@
             </description>
             <category>920</category>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2012-12-31">
             <code>92030</code>
             <name>
                 <narrative>Support to local and regional NGOs</narrative>

--- a/lib/schemata/non-embedded-codelist/SectorCategory.xml
+++ b/lib/schemata/non-embedded-codelist/SectorCategory.xml
@@ -163,7 +163,7 @@
                 <narrative xml:lang="fr"/>
             </description>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>230</code>
             <name>
                 <narrative>ENERGY GENERATION AND SUPPLY</narrative>
@@ -384,8 +384,8 @@
         <codelist-item>
             <code>520</code>
             <name>
-                <narrative>Developmental Food Aid/Food Security Assistance</narrative>
-                <narrative xml:lang="fr">Aide Alimentaire Dévelopmentale/Sécurité Alimentaire</narrative>
+                <narrative>Development Food Assistance</narrative>
+                <narrative xml:lang="fr">Aide Alimentaire Dévelopmentale</narrative>
             </name>
             <description>
                 <narrative/>
@@ -443,8 +443,8 @@
                 <narrative xml:lang="fr">Prévention catastrophes/Préparation à leur survenue</narrative>
             </name>
             <description>
-                <narrative>See codes 41050 and 15220 for prevention of floods and conflicts.</narrative>
-                <narrative xml:lang="fr">Voir codes 41050 et 15220 pour la prévention des inondations et des conflits.</narrative>
+                <narrative>See code 43060 for disaster risk reduction.</narrative>
+                <narrative xml:lang="fr">Voir code 43060 pour la réduction des risques de catastrophes.</narrative>
             </description>
         </codelist-item>
         <codelist-item>
@@ -458,7 +458,7 @@
                 <narrative xml:lang="fr"/>
             </description>
         </codelist-item>
-        <codelist-item status="withdrawn">
+        <codelist-item status="withdrawn" withdrawal-date="2012-12-31">
             <code>920</code>
             <name>
                 <narrative>SUPPORT TO NON- GOVERNMENTAL ORGANISATIONS (NGOs)</narrative>


### PR DESCRIPTION
This PR updates the codelists and schemas in the /lib/ directory from their maintained sources of truth. The Validator relies on these codelists and schemas. 

`lib/schemata/non-embedded-codelist/`
  - source of truth: [IATI/IATI-Codelists-NonEmbedded](https://github.com/IATI/IATI-Codelists-NonEmbedded) (master) / xml

`lib/schemata/2.03/`
- `iati-activities-schema.xsd`
- `iati-common.xsd`
- `Iati-organisations-schema.xsd`

  - source of truth: [IATI/IATI-Schemas](https://github.com/IATI/IATI-Schemas/tree/version-2.03) (version-2.03)


`lib/schemata/2.03/codelist/*.xml`

  - source of truth:[ IATI/IATI-Codelists](https://github.com/IATI/IATI-Codelists) / xml (version-2.03)


