### PR TITLE
update activities schemas for previous versions

### DIFF
--- a/lib/schemata/1.01/iati-activities-schema.xsd
+++ b/lib/schemata/1.01/iati-activities-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-activities">
     <xsd:annotation>
@@ -410,7 +410,7 @@
       </xsd:simpleContent>
     </xsd:complexType>
   </xsd:element>
-
+  
   <xsd:element name="activity-status" type="codeType">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
@@ -661,7 +661,7 @@
               <xsd:documentation xml:lang="en">
                 Optional element to override the top-level
                 default-flow-type element.
-
+                
                 For the value of the @code attribute, see
                 http://iatistandard.org/codelists/flow_type
               </xsd:documentation>

--- a/lib/schemata/1.02/iati-activities-schema.xsd
+++ b/lib/schemata/1.02/iati-activities-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-activities">
     <xsd:annotation>

--- a/lib/schemata/1.03/iati-activities-schema.xsd
+++ b/lib/schemata/1.03/iati-activities-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-activities">
     <xsd:annotation>

--- a/lib/schemata/1.04/iati-activities-schema.xsd
+++ b/lib/schemata/1.04/iati-activities-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-activities">
     <xsd:annotation>

--- a/lib/schemata/1.05/iati-activities-schema.xsd
+++ b/lib/schemata/1.05/iati-activities-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-activities">
     <xsd:annotation>

--- a/lib/schemata/2.01/iati-activities-schema.xsd
+++ b/lib/schemata/2.01/iati-activities-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-activities">
     <xsd:annotation>
@@ -838,7 +838,7 @@
           <xsd:annotation>
             <xsd:documentation xml:lang="en">
               A description of the policy marker. This MUST ONLY be
-              used where vocabulary = "99 - RO" (the reporting
+              used if vocabulary is 99 (the reporting
               organisation's own marker vocabulary). May be repeated
               for multiple languages.
             </xsd:documentation>
@@ -1932,12 +1932,7 @@
   <xsd:element name="budget">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
-        The value of the aid activity's budget for each financial
-        quarter or year over the lifetime of the activity. The total
-        budget for an activity should be reported as a commitment in
-        the transaction element. The purpose of this element is to
-        provide predictability for recipient planning on an annual
-        basis.
+        The value of the activity's budget for each financial quarter or year over the lifetime of the activity. The purpose of this element is to provide predictability for recipient planning on an annual basis. The status explains whether the budget being reported is indicative or has been formally committed. The value should appear within the BudgetStatus codelist. If the @status attribute is not present, the budget is assumed to be indicative. The sum of budgets may or may not match the sum of commitments, depending on a publisher’s business model and legal frameworks.
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType>

--- a/lib/schemata/2.02/iati-activities-schema.xsd
+++ b/lib/schemata/2.02/iati-activities-schema.xsd
@@ -23,7 +23,7 @@
   <xsd:include schemaLocation="iati-common.xsd"/>
 
   <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
-              schemaLocation="../xml.xsd"/>
+              schemaLocation="xml.xsd"/>
 
   <xsd:element name="iati-activities">
     <xsd:annotation>
@@ -924,7 +924,7 @@
           <xsd:annotation>
             <xsd:documentation xml:lang="en">
               A description of the policy marker. This MUST ONLY be
-              used where vocabulary = "99 - RO" (the reporting
+              used if vocabulary is 99 (the reporting
               organisation's own marker vocabulary). May be repeated
               for multiple languages.
             </xsd:documentation>
@@ -2207,18 +2207,7 @@
   <xsd:element name="budget">
     <xsd:annotation>
       <xsd:documentation xml:lang="en">
-        The value of the aid activity's budget for each financial
-        quarter or year over the lifetime of the activity. The total
-        budget for an activity should be reported as a commitment in
-        the transaction element. The purpose of this element is to
-        provide predictability for recipient planning on an annual
-        basis. The status explains whether the budget being reported 
-        is indicative or has been formally committed. The value 
-        should appear within the BudgetStatus codelist. If the @status 
-        attribute is not present, the budget is assumed to be 
-        indicative. While it is useful for the sum of budgets to match 
-        the sum of commitments this is not necessarily the case, 
-        depending on a publisher's business model and legal frameworks. 
+        The value of the activity's budget for each financial quarter or year over the lifetime of the activity. The purpose of this element is to provide predictability for recipient planning on an annual basis. The status explains whether the budget being reported is indicative or has been formally committed. The value should appear within the BudgetStatus codelist. If the @status attribute is not present, the budget is assumed to be indicative. The sum of budgets may or may not match the sum of commitments, depending on a publisher’s business model and legal frameworks.
       </xsd:documentation>
     </xsd:annotation>
     <xsd:complexType>


### PR DESCRIPTION
An issue in the script I used to copy the iati-activities-schema.xsd files for v2.02 and previous meant that these were not updated in the IATI-Rulesets master branch of the .xslt style rules and therefore not included in the latest Validator version.

Previous PR:
https://github.com/IATI/IATI-Rulesets/pull/235/