### PR TITLE
re-order codelist apply-template to fix circularity error in saxonjs

### DIFF
--- a/rules/iati.xslt
+++ b/rules/iati.xslt
@@ -74,17 +74,6 @@
 
   <xsl:template match="@*|node()" mode="rules"/>
 
-  <xsl:template match="codelist" mode="get-codelists">
-    <xsl:copy>
-      <xsl:copy select="@name"/>
-      <xsl:apply-templates select="//code" mode="get-codelists"/>
-    </xsl:copy>
-  </xsl:template>
-  
-  <xsl:template match="code" mode="get-codelists">
-    <xsl:copy>{.}</xsl:copy>
-  </xsl:template>  
-
   <xsl:variable name="iati-codelists">
     <codes version="2.03">
       <xsl:apply-templates select="collection('../lib/schemata/2.03/codelist/?select=*.xml;recurse=yes')" mode="get-codelists"/>
@@ -108,6 +97,17 @@
       <xsl:apply-templates select="collection('../lib/schemata/1.03/codelist/?select=*.xml;recurse=yes')" mode="get-codelists"/>
     </codes>
   </xsl:variable>
+
+  <xsl:template match="codelist" mode="get-codelists">
+    <xsl:copy>
+      <xsl:copy select="@name"/>
+      <xsl:apply-templates select="//code" mode="get-codelists"/>
+    </xsl:copy>
+  </xsl:template>
+  
+  <xsl:template match="code" mode="get-codelists">
+    <xsl:copy>{.}</xsl:copy>
+  </xsl:template>  
 
   <xsl:function name="me:codeListFail" as="xs:boolean">
     <xsl:param name="code"/>


### PR DESCRIPTION
## Issue
When trying to apply iati.xslt transform on an IATI xml file with Saxon-JS the codelists rules were not being applied. I traced this back to the following error:
`xsl:message evaluation at iati.xslt#-1 failed: XError:Circularity in global variable Q{}iati-codelists; code:XTDE0640`

 This seems to have occurred because the following templates were declared before the "iati-codelists" variable was defined.
```
  <xsl:template match="codelist" mode="get-codelists">
    <xsl:copy>
      <xsl:copy select="@name"/>
      <xsl:apply-templates select="//code" mode="get-codelists"/>
    </xsl:copy>
  </xsl:template>
  
  <xsl:template match="code" mode="get-codelists">
    <xsl:copy>{.}</xsl:copy>
  </xsl:template>  

  <xsl:variable name="iati-codelists">
    <codes version="2.03">
      <xsl:apply-templates select="collection('../lib/schemata/2.03/codelist/?select=*.xml;recurse=yes')" mode="get-codelists"/>
      <xsl:apply-templates select="collection('../lib/schemata/non-embedded-codelist/?select=*.xml;recurse=yes')" mode="get-codelists"/>
    </codes>
    <codes version="2.02">
      <xsl:apply-templates select="collection('../lib/schemata/2.02/codelist/?select=*.xml;recurse=yes')" mode="get-codelists"/>
      <xsl:apply-templates select="collection('../lib/schemata/non-embedded-codelist/?select=*.xml;recurse=yes')" mode="get-codelists"/>
    </codes>
...
  </xsl:variable>
```

Swapping the order of these resolved the issue in Saxon-JS. It does not seem to affect this implementation either as I've re-run the `ant test` suite and get the same result as the master branch.

