### PR TITLE
xslt optimisation

### DIFF
--- a/rules/iati.xslt
+++ b/rules/iati.xslt
@@ -34,7 +34,7 @@
   
   <xsl:template match="/*[starts-with(@version, '1.')]">
     <xsl:copy select=".">
-      <xsl:copy-of select="@*"/>
+      <xsl:copy-of select="attribute()"/>
       <me:feedback type="danger" class="documents" id="0.6.1">
         <me:src ref="iati" versions="1.0x" href="https://iatistandard.org/en/news/notice-iati-standard-version-1-is-deprecated/"/>
         <me:message>Version {me:iati-version(@version)} of the IATI Standard is no longer supported. Please use version 2.</me:message>
@@ -42,7 +42,7 @@
     </xsl:copy>
   </xsl:template>
   
-  <xsl:template match="@*|node()">
+  <xsl:template match="attribute()|node()">
     <xsl:param name="iati-version" tunnel="yes"/>
     <xsl:copy>
       <xsl:variable name="use-iati-version">
@@ -57,10 +57,10 @@
         <xsl:attribute name="me:schemaVersion">{$schemaVersion}</xsl:attribute>  
         <xsl:attribute name="me:iatiVersion">{$use-iati-version}</xsl:attribute>  
       </xsl:if>
-      <xsl:apply-templates select="@*|node()">
+      <xsl:apply-templates select="attribute()|node()">
         <xsl:with-param name="iati-version" select="$use-iati-version" tunnel="yes"/>
       </xsl:apply-templates>
-      <xsl:apply-templates select="@*" mode="rules">
+      <xsl:apply-templates select="attribute()" mode="rules">
         <xsl:with-param name="iati-version" select="$use-iati-version" tunnel="yes"/>
       </xsl:apply-templates>
       <xsl:apply-templates select="." mode="rules">
@@ -72,7 +72,7 @@
     </xsl:copy>
   </xsl:template>
 
-  <xsl:template match="@*|node()" mode="rules"/>
+  <xsl:template match="attribute()|node()" mode="rules"/>
 
   <xsl:variable name="iati-codelists">
     <codes version="2.03">

--- a/rules/iati.xslt
+++ b/rules/iati.xslt
@@ -113,10 +113,11 @@
     <xsl:param name="code"/>
     <xsl:param name="codelist"/>
     <xsl:param name="iati-version"/>
+    <xsl:variable name="iati-codelist-version-codelist" select="$iati-codelists/codes[@version=$iati-version]/codelist[@name=$codelist]"/>
     
     <xsl:sequence select="$code and 
-      $iati-codelists/codes[@version=$iati-version]/codelist[@name=$codelist] and 
-      not(($code, lower-case($code), upper-case($code))=$iati-codelists/codes[@version=$iati-version]/codelist[@name=$codelist]/code)"/>
+      $iati-codelist-version-codelist and 
+      not(($code, lower-case($code), upper-case($code))=$iati-codelist-version-codelist/code)"/>
   </xsl:function>
   
 </xsl:stylesheet>

--- a/rules/iati/identifiers.xslt
+++ b/rules/iati/identifiers.xslt
@@ -6,6 +6,8 @@
   exclude-result-prefixes="functx"
   expand-text="yes">
 
+  <xsl:key name="activityByIdentifier" match="iati-identifier" use="text()" />
+
   <xsl:template match="iati-identifier" mode="rules" priority="1.1">
     <xsl:param name="iati-version" tunnel="yes"/>
     <xsl:param name="reporting-org" select="../reporting-org/@ref" />
@@ -38,15 +40,14 @@
         </me:feedback>
       </xsl:when>
     </xsl:choose>
-
-    <!-- TODO move this to an activity file-level test -->
-    <xsl:if test="../../iati-activity[iati-identifier=current()][2]">
+    
+    <xsl:if test="key('activityByIdentifier', .)[2]">
       <me:feedback type="danger" class="identifiers" id="1.1.2">
         <me:src ref="iati" versions="any" href="{me:iati-url('activity-standard/iati-activities/iati-activity/iati-identifier/')}"/>
         <me:message>The activity identifier must be unique for each activity.</me:message>
       </me:feedback>
     </xsl:if>
-    
+
     <xsl:next-match/>
   </xsl:template>
     

--- a/rules/iati/identifiers.xslt
+++ b/rules/iati/identifiers.xslt
@@ -8,7 +8,9 @@
 
   <xsl:template match="iati-identifier" mode="rules" priority="1.1">
     <xsl:param name="iati-version" tunnel="yes"/>
-    
+    <xsl:param name="reporting-org" select="../reporting-org/@ref" />
+    <xsl:param name="other-identifier-B1" select="../other-identifier[@type='B1']/@ref" />
+
     <xsl:call-template name="identifier_check">
       <xsl:with-param name="item" select="."/>
       <xsl:with-param name="class">identifiers</xsl:with-param>
@@ -16,20 +18,20 @@
     </xsl:call-template>    
     
     <xsl:choose>
-      <xsl:when test="not(some $id in (../reporting-org/@ref, ../other-identifier[@type='B1']/@ref) satisfies starts-with(., $id))">
+      <xsl:when test="not(some $id in ($reporting-org, $other-identifier-B1) satisfies starts-with(., $id))">
         <me:feedback type="warning" class="identifiers" id="1.1.1">
           <me:src ref="iati" versions="any"/>
           <me:message>The activity identifier should begin with the organisation identifier of the reporting organisation (or a previous version included in the other-identifier element).</me:message>
         </me:feedback>
       </xsl:when>
-      <xsl:when test=". = ../reporting-org/@ref">
+      <xsl:when test=". = $reporting-org">
         <me:feedback type="danger" class="identifiers" id="1.1.3">
           <me:src ref="iati" versions="any" href="{me:iati-url('activity-standard/iati-activities/iati-activity/iati-identifier/')}"/>
           <me:message>The activity identifier must be different to the organisation identifier of the reporting organisation.</me:message>
         </me:feedback>
       </xsl:when>
       <xsl:when test="$iati-version = '2.03' and
-        not(some $id in (../reporting-org/@ref, ../other-identifier[@type='B1']/@ref) satisfies matches(., functx:escape-for-regex($id) || '-.+'))">
+        not(some $id in ($reporting-org, $other-identifier-B1) satisfies matches(., functx:escape-for-regex($id) || '-.+'))">
         <me:feedback type="warning" class="identifiers" id="1.1.21">
           <me:src ref="iati" versions="2.03" href="{me:iati-url('activity-standard/iati-activities/iati-activity/iati-identifier/')}"/>
           <me:message>The activity identifier should be your IATI Organisation Identifier followed by a unique string for the activity separated by a hyphen e.g. COH-1234-activity1</me:message>


### PR DESCRIPTION
A few small updates as part of the creation of Validator V2:
- use parameters for re-used XPath selects
- use key for duplicate iati-identifier check
- use attribute() instead of *@ for better semantic meaning
- add variable in codeListFail
