### PR TITLE
Validator V2 Updates - v2.03

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,33 +86,33 @@ jobs:
             exit 1
           fi
 
-  cache-ruleset-prod:
-    needs: cache-ruleset-dev
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Number of commits to fetch. 0 indicates all history for all branches and tags.
-          fetch-depth: 0
+  # cache-ruleset-prod:
+  #   needs: cache-ruleset-dev
+  #   runs-on: ubuntu-latest
+  #   if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         # Number of commits to fetch. 0 indicates all history for all branches and tags.
+  #         fetch-depth: 0
 
-      - name: POST ruleset/standard.json to func-iati-redis-cacher-PROD
-        run: |
-          FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
-          echo $FILE_COMMIT_SHA
-          HTTP_CODE=$(curl --write-out "%{http_code}\n" \
-          --location --request POST 'https://func-iati-redis-cacher-prod.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \
-          --header 'x-functions-key: '$PROD_DEFAULT_KEY \
-          --header 'Content-Type: application/json' \
-          --data-binary '@./rulesets/standard.json' \
-          --output curl_out.txt \
-          --silent )
-          echo $HTTP_CODE
-          if [[ $HTTP_CODE != '200' ]] ; then
-            echo "Reponse is not 200 from func-iati-redis-cacher-PROD, check error logs"
-            cat curl_out.txt
-            exit 1
-          fi
+  #     - name: POST ruleset/standard.json to func-iati-redis-cacher-PROD
+  #       run: |
+  #         FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
+  #         echo $FILE_COMMIT_SHA
+  #         HTTP_CODE=$(curl --write-out "%{http_code}\n" \
+  #         --location --request POST 'https://func-iati-redis-cacher-prod.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \
+  #         --header 'x-functions-key: '$PROD_DEFAULT_KEY \
+  #         --header 'Content-Type: application/json' \
+  #         --data-binary '@./rulesets/standard.json' \
+  #         --output curl_out.txt \
+  #         --silent )
+  #         echo $HTTP_CODE
+  #         if [[ $HTTP_CODE != '200' ]] ; then
+  #           echo "Reponse is not 200 from func-iati-redis-cacher-PROD, check error logs"
+  #           cat curl_out.txt
+  #           exit 1
+  #         fi
 
   update-rule-tracker:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ name: CI_version-2.03
 
 env:
   DEV_DEFAULT_KEY: ${{ secrets.DEV_CACHER_DEFAULT_KEY }} # Azure Functions default API Key for Redis-cacher
+  PROD_DEFAULT_KEY: ${{ secrets.PROD_CACHER_DEFAULT_KEY }} # Azure Functions default API Key for Redis-cacher
   VERSION: 2.03
 
 on:
@@ -59,7 +60,7 @@ jobs:
           python -m jsonschema -i rulesets/standard.json schema.json
           ./meta_tests.sh python testrules.py
 
-  cache-ruleset:
+  cache-ruleset-dev:
     needs: build
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
@@ -69,7 +70,7 @@ jobs:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0
 
-      - name: POST ruleset/standard.json to redis-cacher
+      - name: POST ruleset/standard.json to func-iati-redis-cacher-dev
         run: |
           FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
           echo $FILE_COMMIT_SHA
@@ -82,7 +83,35 @@ jobs:
           --silent )
           echo $HTTP_CODE
           if [[ $HTTP_CODE != '200' ]] ; then
-            echo "Reponse is not 200 from redis-cacher, check error logs"
+            echo "Reponse is not 200 from func-iati-redis-cacher-dev, check error logs"
+            cat curl_out.txt
+            exit 1
+          fi
+
+  cache-ruleset-prod:
+    needs: cache-ruleset-dev
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
+
+      - name: POST ruleset/standard.json to func-iati-redis-cacher-PROD
+        run: |
+          FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
+          echo $FILE_COMMIT_SHA
+          HTTP_CODE=$(curl --write-out "%{http_code}\n" \
+          --location --request POST 'https://func-iati-redis-cacher-prod.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \
+          --header 'x-functions-key: '$PROD_DEFAULT_KEY \
+          --header 'Content-Type: application/json' \
+          --data-binary '@./rulesets/standard.json' \
+          --output curl_out.txt \
+          --silent )
+          echo $HTTP_CODE
+          if [[ $HTTP_CODE != '200' ]] ; then
+            echo "Reponse is not 200 from func-iati-redis-cacher-PROD, check error logs"
             cat curl_out.txt
             exit 1
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,8 +68,9 @@ jobs:
 
       - name: POST ruleset/standard.json to redis-cacher
         run: |
+          FILE_SHA=$(git log -n 1 --format=%H ./rulesets/standard.json)
           HTTP_CODE=$(curl --write-out "%{http_code}\n" \
-          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$GITHUB_SHA \
+          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_SHA \
           --header 'x-functions-key: '$DEV_DEFAULT_KEY \
           --header 'Content-Type: application/json' \
           --data-binary '@./rulesets/standard.json' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: POST ruleset/standard.json to redis-cacher
         run: |
-          FILE_COMMIT_SHA=$(git log -1 --format='%H' ./rulesets/standard.json)
+          FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
           echo $FILE_COMMIT_SHA
           HTTP_CODE=$(curl --write-out "%{http_code}\n" \
           --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
       - name: POST ruleset/standard.json to redis-cacher
         run: |
           HTTP_CODE=$(curl --write-out "%{http_code}\n" \
-          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION \
+          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$GITHUB_SHA \
           --header 'x-functions-key: '$DEV_DEFAULT_KEY \
           --header 'Content-Type: application/json' \
           --data-binary '@./rulesets/standard.json' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,9 @@ jobs:
     if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
 
       - name: POST ruleset/standard.json to redis-cacher
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,9 +68,10 @@ jobs:
 
       - name: POST ruleset/standard.json to redis-cacher
         run: |
-          FILE_SHA=$(git log -n 1 --format=%H ./rulesets/standard.json)
+          FILE_COMMIT_SHA=$(git log -1 --format='%H' ./rulesets/standard.json)
+          echo $FILE_COMMIT_SHA
           HTTP_CODE=$(curl --write-out "%{http_code}\n" \
-          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_SHA \
+          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \
           --header 'x-functions-key: '$DEV_DEFAULT_KEY \
           --header 'Content-Type: application/json' \
           --data-binary '@./rulesets/standard.json' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,10 @@ env:
 on:
   push:
     paths-ignore: # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
-      - "**/README.md"
       - "**/*.rst"
     branches: [version-2.03, v2.03/validatorV2]
   pull_request:
     paths-ignore:
-      - "**/README.md"
       - "**/*.rst"
     branches: [version-2.03]
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,3 +81,15 @@ jobs:
             cat curl_out.txt
             exit 1
           fi
+
+  update-rule-tracker:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }} # only push to the rule tracker on PUSH
+    steps:
+      - name: "Trigger update of rule tracker repo .csv"
+        run: |
+          curl -X POST https://api.github.com/repos/IATI/validator-rule-tracker/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.NJO_PAT }} \
+          --data '{"event_type": "update", "client_payload": { "resourceName": "rulesets", "repo": "'"$GITHUB_REPOSITORY"'", "sha": "'"$GITHUB_SHA"'"}}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,13 @@
 
 name: CI_version-2.03
 
+env:
+  DEV_DEFAULT_KEY: ${{ secrets.DEV_CACHER_DEFAULT_KEY }} # Azure Functions default API Key for Redis-cacher
+  VERSION: 2.03
+
 on:
   push:
-    branches: [version-2.03]
+    branches: [version-2.03, v2.03/validatorV2]
   pull_request:
     branches: [version-2.03]
 
@@ -48,3 +52,26 @@ jobs:
         run: |
           python -m jsonschema -i rulesets/standard.json schema.json
           ./meta_tests.sh python testrules.py
+
+  cache-ruleset:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: POST ruleset/standard.json to redis-cacher
+        run: |
+          HTTP_CODE=$(curl --write-out "%{http_code}\n" \
+          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION \
+          --header 'x-functions-key: '$DEV_DEFAULT_KEY \
+          --header 'Content-Type: application/json' \
+          --data-binary '@./rulesets/standard.json' \
+          --output curl_out.txt \
+          --silent )
+          echo $HTTP_CODE
+          if [[ $HTTP_CODE != '200' ]] ; then
+            echo "Reponse is not 200 from redis-cacher, check error logs"
+            cat curl_out.txt
+            exit 1
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,14 @@ env:
 
 on:
   push:
+    paths-ignore: # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - "**/README.md"
+      - "**/*.rst"
     branches: [version-2.03, v2.03/validatorV2]
   pull_request:
+    paths-ignore:
+      - "**/README.md"
+      - "**/*.rst"
     branches: [version-2.03]
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 pyenv*
 doc/_build
 build
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pyenv*
 doc/_build
 build
 .DS_Store
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -3,25 +3,28 @@ IATI-Rulesets
 .. image:: https://github.com/IATI/IATI-Rulesets/workflows/CI_version-2.03/badge.svg
     :target: https://github.com/IATI/IATI-Rulesets/actions
 
-.. image:: https://requires.io/github/IATI/IATI-Rulesets/requirements.svg?branch=version-2.01
-    :target: https://requires.io/github/IATI/IATI-Rulesets/requirements/?branch=version-2.01
+.. image:: https://requires.io/github/IATI/IATI-Rulesets/requirements.svg?branch=version-2.03
+    :target: https://requires.io/github/IATI/IATI-Rulesets/requirements/?branch=version-2.03
     :alt: Requirements Status
 .. image:: https://img.shields.io/badge/license-MIT-blue.svg
-    :target: https://github.com/IATI/IATI-Rulesets/blob/version-2.01/LICENSE
+    :target: https://github.com/IATI/IATI-Rulesets/blob/version-2.03/LICENSE
 
 Introduction
 ============
 
-This is the source repository for the rulesets, more general information can be found on the IATIStandard website: http://iatistandard.org/rulesets/
+This is the source repository for the rulesets, more general information can be found on the IATIStandard website: https://iatistandard.org/rulesets/
 
-These rulesets are part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see http://iatistandard.org/developer/ssot/
+These rulesets are part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see https://iatistandard.org/developer/ssot/
 
 
-As part of the **new Validator work**, the JSON-based rules have been migrated to an XSLT-based system, and some additional checks and feedback messages have been added in line with the IATI Standard.
+As part of the **V1 Validator work**, the JSON-based rules have been migrated to an XSLT-based system, and some additional checks and feedback messages have been added in line with the IATI Standard.
 Please see D4D's `IATI data validator <https://github.com/data4development/IATI-data-validator>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
 IATI's Reference Site will be updated as the testing period progresses. Please refer to the new Validator's `XSLT-based Ruleset <https://github.com/data4development/IATI-Rulesets>`_ repository for an up-to-date version of each rule's narrative.
 Email us on support@iatistandard.org for further clarification.
 
+As part of the **V2 Validator work**, the JSON-based rules have been enhanced and some additional checks and feedback messages have been added in line with the IATI Standard. See `SPEC_JS <SPEC_JS.rst>`_ for more detail.
+A new JavaScript (Node) implementation of the Ruleset validator has been developed as well. Please see IATI's `IATI js validator api <https://github.com/IATI/js-validator-api>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
+Email us on support@iatistandard.org for further clarification.
 
 Information for developers
 ==========================
@@ -43,7 +46,17 @@ A ruleset is a JSON file which applies different rules to various paths in diffe
         "//iati-activity": {
             "atleast_one": {
                 "cases": [
-                    { "paths": ["iati-identifier"] }
+                    { "paths": ["iati-identifier"],
+                      "ruleInfo": {
+                        "id": "6.11.1",
+                        "severity": "error",
+                        "category": "information",
+                        "message": "The activity must have a planned start date or an actual start date.",
+                        "link": {
+                            "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+                        } 
+                      }
+                    }
                 ]
             }
         }
@@ -51,11 +64,16 @@ A ruleset is a JSON file which applies different rules to various paths in diffe
 
 Here we have a context: ``iati-activity``, with a single name rule `atleast_one` which is applied in a number of cases - here just one, with a single path.
 
-A more thorough description of this, along with a list of all rule names can be found in the `Spec <https://github.com/IATI/IATI-Rulesets/blob/version-2.02/SPEC.rst>`_.
+The ``ruleInfo`` object includes metadata about the rule which is used in the `IATI js validator api <https://github.com/IATI/js-validator-api>`_
 
+A more thorough description of this, along with a list of all rule names can be found in the `Spec <SPEC_JS.rst>`_.
+
+A description of the earlier Python based implementation can be found in the `Spec <SPEC.rst>`_.
 
 Ruleset Tester
 ==============
+
+**NOTE** : The following Python tests have not been updated for the new JavaScript implementation of the rulesets and therefore are not comprehensive in testing IATI XML. Use the `IATI js validator api <https://github.com/IATI/js-validator-api>`_ for comprehensive testing.
 
 A program is required to test whether a given xml file conforms to the rules in a ruleset JSON file. The rulesets is designed such that implementations of this can be made in multiple programming languages, so long as they implement the `Spec <https://github.com/IATI/IATI-Rulesets/blob/version-2.02/SPEC.rst>`_.
 
@@ -85,7 +103,6 @@ Different Rulesets
 Rules not describable by a Ruleset
 ==================================
 
-* Testing whether an element is on a certain codelist - this belongs in the IATI-Codelists (see `testcodelists.py <https://github.com/IATI/IATI-Codelists/blob/version-2.02/testcodelists.py>`_)
+* Testing whether an element is on a certain codelist - this belongs in the IATI-Codelists (see `testcodelists.py <https://github.com/IATI/IATI-Codelists/blob/version-2.03/testcodelists.py>`_)
 
 * Testing whether identifier are correct (e.g. uniqueness etc) - this requires information outside the scope of a single activity/file, whereas currently the rulesets operate in just this context. This may change in the future.
-

--- a/README.rst
+++ b/README.rst
@@ -12,18 +12,18 @@ IATI-Rulesets
 Introduction
 ============
 
-This is the source repository for the rulesets, more general information can be found on the IATIStandard website: https://iatistandard.org/rulesets/
+This is the source repository for the rulesets, more general information can be found on the IATI Standard website: https://iatistandard.org/en/iati-standard/203/rulesets/
 
-These rulesets are part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see https://iatistandard.org/developer/ssot/
+These rulesets are part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see https://iatistandard.org/en/guidance/developer/ssot/
 
 
-As part of the **V1 Validator work**, the JSON-based rules have been migrated to an XSLT-based system, and some additional checks and feedback messages have been added in line with the IATI Standard.
-Please see D4D's `IATI data validator <https://github.com/data4development/IATI-data-validator>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
-IATI's Reference Site will be updated as the testing period progresses. Please refer to the new Validator's `XSLT-based Ruleset <https://github.com/data4development/IATI-Rulesets>`_ repository for an up-to-date version of each rule's narrative.
+As part of the **V1 Validator work**, the JSON-based rules were migrated to an XSLT-based system, and some additional checks and feedback messages have been added in line with the IATI Standard.
+Please see `IATI Validator Actual <https://github.com/IATI/IATI-Validator-Actual>`_  repository for information about the V1 tool and to report bugs, issues, and other feedback.
+Please refer to the new Validator's `XSLT-based Ruleset <https://github.com/IATI/IATI-Rulesets#master>`_ repository for an up-to-date version of each rule's narrative.
 Email us on support@iatistandard.org for further clarification.
 
 As part of the **V2 Validator work**, the JSON-based rules have been enhanced and some additional checks and feedback messages have been added in line with the IATI Standard. See `SPEC_JS <SPEC_JS.rst>`_ for more detail.
-A new JavaScript (Node) implementation of the Ruleset validator has been developed as well. Please see IATI's `IATI js validator api <https://github.com/IATI/js-validator-api>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
+A new JavaScript (Node) implementation of the Ruleset validator has been developed as well. Please see `IATI Validator API <https://github.com/IATI/js-validator-api>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
 Email us on support@iatistandard.org for further clarification.
 
 Information for developers
@@ -75,7 +75,7 @@ Ruleset Tester
 
 **NOTE** : The following Python tests have not been updated for the new JavaScript implementation of the rulesets and therefore are not comprehensive in testing IATI XML. Use the `IATI js validator api <https://github.com/IATI/js-validator-api>`_ for comprehensive testing.
 
-A program is required to test whether a given xml file conforms to the rules in a ruleset JSON file. The rulesets is designed such that implementations of this can be made in multiple programming languages, so long as they implement the `Spec <https://github.com/IATI/IATI-Rulesets/blob/version-2.02/SPEC.rst>`_.
+A program is required to test whether a given xml file conforms to the rules in a ruleset JSON file. The rulesets is designed such that implementations of this can be made in multiple programming languages, so long as they implement the `Spec <https://github.com/IATI/IATI-Rulesets/blob/version-2.03/SPEC.rst>`_.
 
 Currently, a Python `<testrules.py>`_ tester is available. E.g.
 
@@ -96,7 +96,7 @@ Tests for Testers
 Different Rulesets
 ==================
 
-* ``standard.json`` is a ruleset that tries to describe compliance to the standard
+* ``standard.json`` is a ruleset that tries to describe compliance to the standard, this is used by the `IATI js validator api <https://github.com/IATI/js-validator-api>`_
 * ``dfid.json`` is a more comprehensive set of rules based on DFID's requirements for organisations it works with
 * ``ti-fallbacks.json`` finds problems with data that had to be worked around (using fallbacks) in transparency indicator tests
 
@@ -106,3 +106,5 @@ Rules not describable by a Ruleset
 * Testing whether an element is on a certain codelist - this belongs in the IATI-Codelists (see `testcodelists.py <https://github.com/IATI/IATI-Codelists/blob/version-2.03/testcodelists.py>`_)
 
 * Testing whether identifier are correct (e.g. uniqueness etc) - this requires information outside the scope of a single activity/file, whereas currently the rulesets operate in just this context. This may change in the future.
+
+Both the above rules are included as part of the `IATI js validator api <https://github.com/IATI/js-validator-api>`_. Please see that repository for more information.

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ This tool supports Python 3.x. To use this script, we recommend the use of a vir
 Ruleset Structure
 =================
 
-A ruleset is a JSON file which applies different rules to various paths in different elements. Structure:
+A ruleset is a JSON file which applies different rules to various paths in different elements. Example Structure:
 
 .. code-block:: json
     
@@ -46,16 +46,17 @@ A ruleset is a JSON file which applies different rules to various paths in diffe
         "//iati-activity": {
             "atleast_one": {
                 "cases": [
-                    { "paths": ["iati-identifier"],
-                      "ruleInfo": {
-                        "id": "6.11.1",
-                        "severity": "error",
-                        "category": "information",
-                        "message": "The activity must have a planned start date or an actual start date.",
-                        "link": {
-                            "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
-                        } 
-                      }
+                    { 
+                        "paths": ["iati-identifier"],
+                        "ruleInfo": {
+                            "id": "6.11.1",
+                            "severity": "error",
+                            "category": "information",
+                            "message": "The activity must have a planned start date or an actual start date.",
+                            "link": {
+                                "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+                            } 
+                        }
                     }
                 ]
             },
@@ -80,7 +81,13 @@ A ruleset is a JSON file which applies different rules to various paths in diffe
         }
     }
 
-Here we have a context: ``iati-activity``, with a single name rule `atleast_one` which is applied in a number of cases - here just one, with a single path.
+Here we have a context: ``iati-activity``, with a two named rules `atleast_one` and `range` which is applied in a number of cases - here just one each, with a single path each.
+
+The full JSON Schema is defined in `<schema.json>`__. 
+
+A more thorough description of this, along with a list of all rule names can be found in the `Spec <SPEC_JS.rst>`_.
+
+A description of the earlier Python based implementation can be found in the `Spec <SPEC.rst>`_.
 
 The ``ruleInfo`` object includes metadata about the rule which is used in the `IATI js validator api <https://github.com/IATI/js-validator-api>`_.
 
@@ -88,9 +95,6 @@ The ``link`` object can contain 2 possible keys which represent the Guidance Lin
 * ``url`` is a full URL to the guidance
 * ``path`` is the path to be added to the end of the reference documentation url for the version of standard. (e.g. https://iatistandard.org/en/iati-standard/{version}/{path})
 
-A more thorough description of this, along with a list of all rule names can be found in the `Spec <SPEC_JS.rst>`_.
-
-A description of the earlier Python based implementation can be found in the `Spec <SPEC.rst>`_.
 
 Ruleset Tester
 ==============

--- a/README.rst
+++ b/README.rst
@@ -58,13 +58,35 @@ A ruleset is a JSON file which applies different rules to various paths in diffe
                       }
                     }
                 ]
+            },
+            "range": {
+                "cases": [
+                    {
+                        "paths": ["capital-spend/@percentage"],
+                        "min": 0.0,
+                        "max": 100.0,
+                        "ruleInfo": {
+                            "id": "12.2.1",
+                            "severity": "error",
+                            "category": "financial",
+                            "message": "The percentage value must be between 0.0 and 100.0 (inclusive).",
+                            "link": {
+                                "path": "activity-standard/iati-activities/iati-activity/capital-spend/"
+                            }
+                        }
+                    }
+                ]
             }
         }
     }
 
 Here we have a context: ``iati-activity``, with a single name rule `atleast_one` which is applied in a number of cases - here just one, with a single path.
 
-The ``ruleInfo`` object includes metadata about the rule which is used in the `IATI js validator api <https://github.com/IATI/js-validator-api>`_
+The ``ruleInfo`` object includes metadata about the rule which is used in the `IATI js validator api <https://github.com/IATI/js-validator-api>`_.
+
+The ``link`` object can contain 2 possible keys which represent the Guidance Links for the rule:
+* ``url`` is a full URL to the guidance
+* ``path`` is the path to be added to the end of the reference documentation url for the version of standard. (e.g. https://iatistandard.org/en/iati-standard/{version}/{path})
 
 A more thorough description of this, along with a list of all rule names can be found in the `Spec <SPEC_JS.rst>`_.
 
@@ -108,3 +130,14 @@ Rules not describable by a Ruleset
 * Testing whether identifier are correct (e.g. uniqueness etc) - this requires information outside the scope of a single activity/file, whereas currently the rulesets operate in just this context. This may change in the future.
 
 Both the above rules are included as part of the `IATI js validator api <https://github.com/IATI/js-validator-api>`_. Please see that repository for more information.
+
+GitHub Actions workflows
+=========================
+
+``.github/workflows/main.yml`` does a few things when new code is pushed to  version-2.0X branches. 
+
+* Runs flake8 linting 
+* Tests that ``rulesets/standard.json`` adheres to the JSON schema defined in ``schema.json``
+* Runs `<meta_tests.sh>`__ 
+* Pushes ``rulesets/standard.json`` to the Redis cache used by the `IATI js validator api <https://github.com/IATI/js-validator-api>`__
+* Triggers a workflow to update the .csv Validator rules in `Validator Rule Tracker <https://github.com/IATI/validator-rule-tracker>`__

--- a/SPEC_JS.rst
+++ b/SPEC_JS.rst
@@ -1,0 +1,166 @@
+
+IATI Ruleset Spec - JS Edition
+=================
+
+An IATI Ruleset is a JSON document. The structure is described below. This specification is specific to the new JavaScript implementation of the Ruleset validator which is part of the 2021 Validator.
+
+A `JSON schema <https://github.com/IATI/IATI-Rulesets/blob/version-2.03/schema.json>`_ is availible to test that the structure of a Ruleset is correct.
+
+Each JSON document has the form.::
+
+    {
+        "CONTEXT": {
+            "RULE_NAME": {
+                "cases": CASE_DICT_ARRAY
+            }
+        }
+
+    }
+
+Where ``CONTEXT`` is an xpath expression. This will be used to select the XML elements that the contained rules will be tested against.
+``RULE_NAME`` is one of rule names listed below
+``CASE_DICT`` is a dictionary where the contents depend on ``RULE_NAME``
+``CASE_DICT_ARRAY`` is an array of case dictionaries. The contents of each dictionary depend on the ``RULE_NAME``
+
+The possible keys in a case dictionary are:
+
+``condition``
+    An xpath string. If this evaluates to False, the rule will be ignored.
+``idCondition``
+    If this evaluates to False, the rule will be ignored.
+    NOT_EXISTING_ORG_ID - Checks that values in ``paths`` are NOT an existing Publisher Organisation ID from the Registry
+    NOT_EXISTING_ORG_ID_PREFIX - Checks that values in ``paths`` are NOT prefixed with an existing Publisher Organisation ID from the Registry
+``eval``
+    An xpath string. Can evaluate to True or False.
+``paths``
+    An array of xpath strings. These are evaluated to give a list of elements that the named rule then operates upon.
+``less``
+    A string containing the xpath of the smaller value (or older value when working with dates).
+``more``
+    A string containing the xpath of the larger value (or more recent value when working with dates).
+``regex``
+    A string containing a perl style regular expression.
+``sum``
+    A number that is the expected sum.
+``excluded``
+    An array of xpath strings. Evaluate which elements should not coexist with other elements.
+``date``
+    A string containing the xpath to a date.
+``start``
+    A string containing the xpath to a start date.
+``end``
+    A string containing the xpath to an end date.
+``one``
+    A string containing the xpath of something that must exist or ``all`` must be followed.
+``all``
+    A string containing the condition that must be met for all elements if ``one`` is not met.
+``foreach``
+    An xpath string to group the loop by and evalute each ``do`` with the substituted result. 
+``do``
+    An array of rules. To evaluate with ``foreach``. Available rules include: ``strict_sum``, ``if_then``, ``atleast_one``, ``no_more_than_one`` 
+``subs``
+    An array of keys where the value matched in ``foreach`` should be substituded for the ``$1`` values in the ``do`` cases.
+``prefix``
+    An array of xpath strings. The matches of which, contain the possible prefixes for a path. If set to "ORG-ID-PREFIX" for startsWith, checks against provided list of prefixes in ``idSets.ORG-ID-PREFIX``. ``idSets`` are passed to the Rule evaluation code.
+
+Rule Names
+----------
+
+**Rule names are listed in bold**
+    Keys: The keys for each rule are then listed. The are listed in **snake-case**/**camel-case**.
+
+    Followed by a brief description of the rule's function.
+
+
+**no_more_than_one**/**noMoreThanOne**
+    Keys: ``condition``, ``paths``
+
+    There must be no more than one element described by the given paths.
+
+**atleast_one**/**atLeastOne**
+    Keys: ``condition``, ``paths``
+
+    There must be at least one element described by the given paths.
+
+**only_one_of**/**onlyOneOf**
+    Keys: ``excluded``, ``paths``
+
+    If there's a match of the elements in ``excluded``, there must not be any matches in ``paths``, if there are no matches in ``excluded``, there must be exactly one element from ``paths``.
+
+**one_or_all**/**oneOrAll**
+    Keys: ``one``, ``all``
+
+    ``one`` must exist otherwise ``all`` other attributes or elements must exist. 
+
+**dependent**/**NOT IMPLEMENTED IN JS**
+    Keys: ``condition``, ``paths``
+
+    If one of the provided paths exists, they must all exist.
+
+**sum**/**sum**
+    Keys: ``condition``, ``paths``, ``sum``
+
+    The numerical sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key
+
+**date_order**/**dateOrder**
+    Keys: ``condition``, ``less``, ``more``
+
+    The date matched by ``less`` must not be after the date matched by ``more``. If they are equal, the are valid. If either of these dates is not found, the rule is ignored.
+    https://drive.google.com/file/d/1-R-xGMCrAKiadMBIHsNc4Xvl75CB0IV1/view
+    
+**date_now**/**dateNow**
+    Keys: ``date``
+
+    The ``date`` must not be after the current date.
+
+**time_limit**/**timeLimit**
+    Keys: ``start``, ``end``
+
+    The difference between the ``start`` date and the ``end`` date must not be greater than a year.
+
+**between_dates**/**betweenDates**
+    Keys: ``date``, ``start``, ``end``
+
+    The ``date`` must be between the ``start`` and ``end`` dates.
+
+**regex_matches**/**regexMatches**
+    Keys: ``condition``, ``idCondition``, ``paths``, ``regex``
+
+    The provided ``regex`` must match the text of all elements matched by ``paths``. ``idCondition`` is also an optional parameter.
+
+**regex_no_matches**/**regexNoMatches**
+    Keys: ``condition``, ``paths``, ``regex``
+
+    The provided ``regex`` must match the text of none of the elements matched by ``paths``.
+
+**startswith**/**startsWith**
+    Keys: ``condition``, ``idCondition``, ``paths``, ``start``, ``separator``
+
+    The text of each element matched by ``paths`` must start with the text of one of the elements matched by ``prefix`` (or a list of prefixed provided in ``idSets``) with an optional ``separator`` in between
+    ``prefix````separator````pathMatchText``. ``idCondition`` is also an optional parameter.
+
+**unique**/**unique**
+    Keys: ``condition``, ``paths``
+
+    The text of each of the elements described by ``paths`` must be unique
+
+**if_then**/**ifThen**
+    Keys: ``condition``, ``cases``, ``if``, ``then``, ``paths``
+
+    If the condition evaluated in ``if`` is true, then ``then`` must resolve to true as well
+    ``paths`` can be defined to provide additional context data in the output if a rule fails, but had no bearing on the pass/fail of the rule 
+
+**loop**/**loop**
+    Keys: ``foreach``, ``do``, ``cases``, ``subs``
+
+    All elements in ``foreach`` are evaluated under the rules inside ``do``
+
+**strict_sum**/**strictSum**
+    Keys: ``paths``, ``sum``
+
+    The decimal sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key
+
+**no_spaces**/**noSpaces**
+    Keys: ``paths``
+
+    The text of each of the elements described by ``paths`` should not start or end with spaces or newlines 

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -1,7 +1,6 @@
 from __future__ import print_function
 import os
 import re
-import copy
 
 
 def human_list(other_paths, separator='or'):
@@ -64,6 +63,4 @@ def rules_text(rules, reduced_path=None):
                                         out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
                         else:
                             out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
-
-
     return out

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -39,6 +39,7 @@ def rule_link(rule_id):
 
 
 def rules_text(rules, reduced_path=None):
+    possible_path_keys = ['less', 'more', 'start', 'end', 'date', 'one']
     out = []
     for rule in rules:
         cases = rules[rule]['cases']
@@ -48,6 +49,11 @@ def rules_text(rules, reduced_path=None):
                     if 'paths' in case:
                         for case_path in case['paths']:
                             if simplify_xpath(case_path) == reduced_path:
+                                out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
+                    included_path_keys = [path_key for path_key in possible_path_keys if path_key in case.keys()]
+                    for included_path_key in included_path_keys:
+                        case_path = case[included_path_key]
+                        if simplify_xpath(case_path) == reduced_path:
                                 out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
                 else:
                     out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
@@ -61,6 +67,13 @@ def rules_text(rules, reduced_path=None):
                                 for sub_case_path in sub_case['paths']:
                                     if simplify_xpath(sub_case_path) == reduced_path:
                                         out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
+                            included_path_keys = [path_key for path_key in possible_path_keys if path_key in sub_case.keys()]
+                            for included_path_key in included_path_keys:
+                                case_path = sub_case[included_path_key]
+                                if simplify_xpath(case_path) == reduced_path:
+                                    out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
                         else:
                             out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
-    return out
+    unique_rules = [tup for tup in (set(tuple(i) for i in out))]
+    unique_rules.sort(key=lambda x: x[0])
+    return unique_rules

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -75,5 +75,5 @@ def rules_text(rules, reduced_path=None):
                         else:
                             out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
     unique_rules = [tup for tup in (set(tuple(i) for i in out))]
-    unique_rules.sort(key=lambda x: x[0])
+    unique_rules.sort(key=lambda x: list(map(int, x[0].split('.'))))
     return unique_rules

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -18,102 +18,20 @@ def extract_from_expr(expr):
     return expr
 
 
-def rules_text(rules, reduced_path, show_all=False):
+def simplify_xpath(xpath):
+    return re.sub(r'\[[^\]]*\]', '', xpath)
+
+
+def rules_text(rules, reduced_path=None):
     out = []
     for rule in rules:
         cases = rules[rule]['cases']
         for case in cases:
-            simplify_xpath = lambda x: re.sub(r'\[[^\]]*\]', '', x)
-            if 'paths' in case:
-                for case_path in case['paths']:
-                    # Don't forget [@ ]
-                    if show_all or simplify_xpath(case_path) == reduced_path:
-                        other_paths = copy.deepcopy(case['paths'])
-                        other_paths.remove(case_path)
-                        if rule == 'only_one':
-                            out.append('``{0}`` must be present only once.'.format(case_path))
-                            if other_paths:
-                                out.append('``{0}`` must not be present if ``{1}`` are present.'.format(case_path, human_list(other_paths)))
-                                break
-                        elif rule == 'atleast_one':
-                            cond = case.get('condition', None)
-                            cond = '.' if not cond else ' if {}'.format(cond)
-
-                            if other_paths:
-                                out.append('Either ``{0}`` or ``{1}`` must be present{2}'.format(case_path, human_list(other_paths), cond))
-                                break
-                            else:
-                                out.append('``{0}`` must be present{1}'.format(case_path, cond))
-
-                        elif rule == 'only_one_of':
-                            out.append('``{0}`` must not be present alongisde ``{1}``.'.format(case_path, human_list(case['excluded'], 'and')))
-                        elif rule == 'startswith':
-                            out.append('``{0}`` should start with the value in ``{1}``'.format(case_path, case['start']))
-                        elif rule == 'regex_matches':
-                            out.append('``{0}`` should match the regex ``{1}``'.format(case_path, case['regex']))
-                        elif rule == 'no_more_than_one':
-                            if other_paths:
-                                out.append('There must be no more than one element or attribute matched at ``{0}`` or ``{1}``.'.format(case_path, human_list(other_paths)))
-                            else:
-                                out.append('There must be no more than one element or attribute matched at ``{0}``.'.format(case_path))
-                        elif rule == 'sum':
-                            sum_total = case['sum']
-                            if other_paths:
-                                out.append('The sum of values matched at ``{0}`` and ``{1}`` must be ``{2}``.'.format(case_path, human_list(other_paths, 'and'), sum_total))
-                                break
-                            else:
-                                out.append('The sum of values matched at ``{0}`` must be ``{2}``.'.format(case_path, sum_total))
-                        elif rule == 'strict_sum':
-                            out.append('The sum of values matched at ``{0}`` must be ``{1}``.'.format(case_path, case['sum']))
-                        elif rule == 'range':
-                            min_val = case.get('min')
-                            max_val = case.get('max')
-                            if min_val is not None or max_val is not None:
-                                # only proceed if one of the two exists
-                                txt = 'The value of each of the elements described by ``{0}`` must be'.format(case_path)
-                                txt += ' at least ``{0}``'.format(min_val) if min_val is not None else ''
-                                txt += ' no more than ``{0}``'.format(max_val) if max_val is not None else ''
-                                txt += ' (inclusive).'
-                                out.append(txt)
-                        else:
-                            print('Not implemented', rule, reduced_path)
+            if reduced_path:
+                if 'paths' in case:
+                    for case_path in case['paths']:
+                        if simplify_xpath(case_path) == reduced_path:
+                            out.append({case['ruleInfo']['id']: case['ruleInfo']['message']})
             else:
-                # rather than checking line-by-line wether reduced_path is in either one of the specific cases
-                # we do a generic check to assess we're rendering the right rule for the right element
-                if rule == 'date_order':
-                    if show_all or reduced_path == simplify_xpath(case['less']) or reduced_path == simplify_xpath(case['more']):
-                        if case['less'] == 'NOW':
-                            out.append('``{0}`` must not be in the past.'.format(case['more']))
-                        elif case['more'] == 'NOW':
-                            out.append('``{0}`` must not be in the future.'.format(case['less']))
-                        else:
-                            out.append('``{0}`` must be before or the same as ``{1}``'.format(case['less'], case['more']))
-
-                elif rule == 'time_limit':
-                    if show_all or reduced_path == simplify_xpath(case['start']) or reduced_path == simplify_xpath(case['end']):
-                        out.append('The time between ``{0}`` and ``{1}`` must not be over a year'.format(case['start'], case['end']))
-
-                elif rule == 'date_now':
-                    if show_all or reduced_path == simplify_xpath(case['date']):
-                        out.append('``{0}`` must not be more recent than the current date'.format(case['date']))
-
-                elif rule == 'if_then':
-                    if_case = extract_from_expr(case['if'])
-                    if show_all or (if_case.startswith(reduced_path) or if_case.endswith(reduced_path)):
-                        out.append('If ``{0}`` evaluates to true, then ``{1}`` must evaluate to true.'.format(case['if'], case['then']))
-
-                elif rule == 'one_or_all':
-                    if show_all or reduced_path == simplify_xpath(case['one']):
-                        out.append('``{0}`` must exist, otherwise all ``{1}`` must exist.'.format(case['one'], case['all']))
-
-                elif rule == 'between_dates':
-                    if show_all or reduced_path == simplify_xpath(case['date']):
-                        out.append('The ``{0}`` must be between the ``{1}`` and ``{2}`` dates.'.format(case['date'], case['start'], case['end']))
-
-                elif rule == 'loop':
-                    continue
-                #   commenting this out and skipping until the way we render this is fixed
-                #   out.append('All elements in ``{0}`` are evaluated under the rules inside ``{1}``.'.format(case['foreach'],case['do']))
-                else:
-                    print('Not implemented', rule, reduced_path)
+                out.append({case['ruleInfo']['id']: case['ruleInfo']['message']})
     return out

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -54,7 +54,7 @@ def rules_text(rules, reduced_path=None):
                     for included_path_key in included_path_keys:
                         case_path = case[included_path_key]
                         if simplify_xpath(case_path) == reduced_path:
-                                out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
+                            out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
                 else:
                     out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
             else:

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -261,6 +261,16 @@
             "category": "information",
             "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used."
           }
+        },
+        {
+          "if": "count(sector) > 0",
+          "then": "count(transaction/sector) < 1",
+          "ruleInfo": {
+            "id": "6.6.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "Sectors must only be declared at activity level OR for all transactions."
+          }
         }
       ]
     }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -208,9 +208,15 @@
           }
         },
         {
-          "condition": "not(recipient-region)",
+          "condition": "recipient-country and not(recipient-region)",
           "paths": ["recipient-country/@percentage"],
-          "sum": 100
+          "sum": 100,
+          "ruleInfo": {
+            "id": "3.1.2",
+            "severity": "error",
+            "category": "geo",
+            "message": "Percentage values for recipient countries, must add up to 100%."
+          }
         }
       ]
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1,300 +1,311 @@
 {
-    "//iati-activity": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "activity-date[@type='1' or @type='2']" ] },
-                { "paths": [ "sector", "transaction/sector" ] }
-            ]
+  "//iati-activity": {
+    "atleast_one": {
+      "cases": [
+        { "paths": ["activity-date[@type='1' or @type='2']"] },
+        { "paths": ["sector", "transaction/sector"] }
+      ]
+    },
+    "one_or_all": {
+      "cases": [
+        { "one": "@xml:lang", "all": "lang" },
+        { "one": "sector", "all": "sector" },
+        { "one": "@default-currency", "all": "currency" }
+      ]
+    },
+    "only_one_of": {
+      "cases": [
+        {
+          "excluded": ["recipient-region", "recipient-country"],
+          "paths": [
+            "transaction/recipient-country",
+            "transaction/recipient-region"
+          ]
+        }
+      ]
+    },
+    "date_now": {
+      "cases": [{ "date": "@last-updated-datetime" }]
+    },
+    "date_order": {
+      "cases": [
+        {
+          "less": "activity-date[@type='1']/@iso-date",
+          "more": "activity-date[@type='3']/@iso-date"
         },
-        "one_or_all": {
-            "cases": [
-                { "one":"@xml:lang", "all":"lang" },
-                { "one":"sector", "all":"sector" },
-                { "one":"@default-currency", "all":"currency" }
-            ]
+        {
+          "less": "activity-date[@type='2']/@iso-date",
+          "more": "activity-date[@type='4']/@iso-date"
         },
-        "only_one_of": {
-            "cases": [
+        { "less": "activity-date[@type='2']/@iso-date", "more": "NOW" },
+        { "less": "activity-date[@type='4']/@iso-date", "more": "NOW" }
+      ]
+    },
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "[^\\/\\&\\|\\?]+",
+          "paths": [
+            "reporting-org/@ref",
+            "iati-identifier",
+            "participating-org/@ref",
+            "transaction/provider-org/@ref",
+            "transaction/receiver-org/@ref"
+          ]
+        }
+      ]
+    },
+    "sum": {
+      "cases": [
+        {
+          "paths": [
+            "recipient-country/@percentage",
+            "recipient-region/@percentage"
+          ],
+          "sum": 100
+        }
+      ]
+    },
+    "loop": {
+      "cases": [
+        {
+          "foreach": "sector[@vocabulary != '1']/@vocabulary",
+          "do": {
+            "strict_sum": {
+              "cases": [
                 {
-                    "excluded": [ "recipient-region", "recipient-country" ],
-                    "paths": [ "transaction/recipient-country", "transaction/recipient-region" ]
+                  "paths": ["sector[@vocabulary = '$1']/@percentage"],
+                  "sum": 100
                 }
-            ]
+              ]
+            }
+          },
+          "subs": ["paths"]
+        }
+      ]
+    },
+    "strict_sum": {
+      "cases": [
+        {
+          "paths": [
+            "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage"
+          ],
+          "sum": 100
+        }
+      ]
+    },
+    "range": {
+      "cases": [
+        {
+          "paths": ["recipient-country/@percentage"],
+          "min": 0.0,
+          "max": 100.0
         },
-        "date_now": {
-            "cases": [
-                { "date": "@last-updated-datetime" }
-            ]
+        {
+          "paths": ["recipient-region/@percentage"],
+          "min": 0.0,
+          "max": 100.0
         },
-        "date_order": {
-            "cases": [
-                { "less": "activity-date[@type='1']/@iso-date", "more": "activity-date[@type='3']/@iso-date" },
-                { "less": "activity-date[@type='2']/@iso-date", "more": "activity-date[@type='4']/@iso-date" },
-                { "less": "activity-date[@type='2']/@iso-date", "more": "NOW" },
-                { "less": "activity-date[@type='4']/@iso-date", "more": "NOW" }
-            ]
+        {
+          "paths": ["sector/@percentage"],
+          "min": 0.0,
+          "max": 100.0
         },
-        "regex_matches": {
-            "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
-                  "paths": [ "reporting-org/@ref", "iati-identifier", "participating-org/@ref", "transaction/provider-org/@ref", "transaction/receiver-org/@ref" ] }
-            ]
+        {
+          "paths": ["capital-spend/@percentage"],
+          "min": 0.0,
+          "max": 100.0
         },
-        "sum": {
-            "cases": [ {
-                "paths": [ "recipient-country/@percentage", "recipient-region/@percentage" ],
-                "sum": 100
-             } ]
-        },
-        "loop": {
-            "cases": [
-                {
-                    "foreach": "sector[@vocabulary != '1']/@vocabulary",
-                    "do": {
-                        "strict_sum": {
-                            "cases": [
-                                {
-                                    "paths": [ "sector[@vocabulary = '$1']/@percentage" ],
-                                    "sum": 100
-                                }
-                            ]
-                        }
-                    },
-                    "subs": ["paths"]
-                }
-            ]
-        },
-        "strict_sum": {
-            "cases": [
-                {
-                    "paths": [ "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage" ],
-                    "sum": 100
-                }
-            ]
-        },
-        "range": {
-            "cases": [
-                {
-                    "paths": ["recipient-country/@percentage"],
-                    "min": 0.0, "max": 100.0
-                },
-                {
-                    "paths": ["recipient-region/@percentage"],
-                    "min": 0.0, "max": 100.0
-                },
-                {
-                    "paths": ["sector/@percentage"],
-                    "min": 0.0, "max": 100.0
-                },
-                {
-                    "paths": ["capital-spend/@percentage"],
-                    "min": 0.0, "max": 100.0
-                },
-                {
-                    "paths": ["country-budget-items/budget-item/@percentage"],
-                    "min": 0.0, "max": 100.0
-                }
-            ]
-        },
-        "if_then": {
-            "cases":[
-                {
-                    "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
-                    "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])"
-                }
-            ]
+        {
+          "paths": ["country-budget-items/budget-item/@percentage"],
+          "min": 0.0,
+          "max": 100.0
         }
+      ]
     },
-    "//iati-activity/other-identifier/owner-org": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@ref", "narrative" ]}
-            ]
+    "if_then": {
+      "cases": [
+        {
+          "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
+          "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])"
         }
-    },
-    "//iati-activity/transaction/provider-org": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@ref", "narrative" ]}
-            ]
-        }
-    },
-    "//iati-activity/transaction/receiver-org": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@ref", "narrative" ]}
-            ]
-        }
-    },
-    "//policy-marker": {
-        "atleast_one": {
-            "cases": [
-                {
-                    "condition": "@vocabulary='1' or not(@vocabulary)",
-                    "paths": [ "@significance" ]
-                },
-                {
-                    "condition": "@vocabulary='99'",
-                    "paths": [ "narrative" ]
-                }
-            ]
-        }
-    },
-    "//iati-organisation": {
-        "regex_matches": {
-            "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
-                  "paths": [ "reporting-org/@ref", "organisation-identifier" ] }
-            ]
-        },
-        "date_now": {
-            "cases": [
-                { "date": "@last-updated-datetime" }
-            ]
-        },
-        "one_or_all": {
-            "cases": [
-                { "one":"@xml:lang", "all":"lang" },
-                { "one":"@default-currency", "all":"currency" }
-            ]
-        }
-    },
-    "//participating-org": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@ref", "narrative" ] }
-            ]
-        }
-    },
-    "//transaction": {
-        "date_order": {
-            "cases": [
-                { "less": "transaction-date/@iso-date", "more": "NOW" },
-                { "less": "value/@value-date", "more": "NOW" }
-            ]
-        }
-    },
-    "//planned-disbursement": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//total-budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                { "start": "period-start/@iso-date", "end": "period-end/@iso-date"}
-            ]
-        }
-    },
-    "//recipient-country-budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        },
-        "between_dates": {
-            "cases": [
-                {
-                    "date": "budget-line/value/@value-date",
-                    "start": "period-start/@iso-date",
-                    "end": "period-end/@iso-date"
-                }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//recipient-org-budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//recipient-region-budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//result/indicator": {
-        "no_more_than_one": {
-            "cases": [
-                { "paths": [ "reference[1]", "../reference[1]" ] }
-            ]
-        }
-    },
-    "//result/indicator/period": {
-        "date_order": {
-            "cases": [
-                {  "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//total-expenditure": {
-        "time_limit": {
-            "cases": [
-                { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
-            ]
-        },
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/baseline": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@value" ] }
-            ]
-        }
-    },
-    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/target": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@value" ] }
-            ]
-        }
-    },
-    "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/actual": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@value" ] }
-            ]
-        }
+      ]
     }
+  },
+  "//iati-activity/other-identifier/owner-org": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@ref", "narrative"] }]
+    }
+  },
+  "//iati-activity/transaction/provider-org": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@ref", "narrative"] }]
+    }
+  },
+  "//iati-activity/transaction/receiver-org": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@ref", "narrative"] }]
+    }
+  },
+  "//policy-marker": {
+    "atleast_one": {
+      "cases": [
+        {
+          "condition": "@vocabulary='1' or not(@vocabulary)",
+          "paths": ["@significance"]
+        },
+        {
+          "condition": "@vocabulary='99'",
+          "paths": ["narrative"]
+        }
+      ]
+    }
+  },
+  "//iati-organisation": {
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "[^\\/\\&\\|\\?]+",
+          "paths": ["reporting-org/@ref", "organisation-identifier"]
+        }
+      ]
+    },
+    "date_now": {
+      "cases": [{ "date": "@last-updated-datetime" }]
+    },
+    "one_or_all": {
+      "cases": [
+        { "one": "@xml:lang", "all": "lang" },
+        { "one": "@default-currency", "all": "currency" }
+      ]
+    }
+  },
+  "//participating-org": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@ref", "narrative"] }]
+    }
+  },
+  "//transaction": {
+    "date_order": {
+      "cases": [
+        { "less": "transaction-date/@iso-date", "more": "NOW" },
+        { "less": "value/@value-date", "more": "NOW" }
+      ]
+    }
+  },
+  "//planned-disbursement": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//total-budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//recipient-country-budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    },
+    "between_dates": {
+      "cases": [
+        {
+          "date": "budget-line/value/@value-date",
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date"
+        }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//recipient-org-budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//recipient-region-budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//result/indicator": {
+    "no_more_than_one": {
+      "cases": [{ "paths": ["reference[1]", "../reference[1]"] }]
+    }
+  },
+  "//result/indicator/period": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//total-expenditure": {
+    "time_limit": {
+      "cases": [
+        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+      ]
+    },
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/baseline": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@value"] }]
+    }
+  },
+  "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/target": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@value"] }]
+    }
+  },
+  "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/actual": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@value"] }]
+    }
+  }
 }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -272,6 +272,16 @@
           }
         },
         {
+          "if": "count(default-aid-type[not(@vocabulary='')]) + count(default-aid-type[not(@vocabulary='1')]) > 0",
+          "then": "count(default-aid-type[@vocabulary='']) + count(default-aid-type[@vocabulary='1']) + count(default-aid-type[not(@vocabulary)]) > 0",
+          "ruleInfo": {
+            "id": "107.1.1",
+            "severity": "warning",
+            "category": "information",
+            "message": "The activity should also declare an aid type code from aid type vocabulary 1 - OECD DAC."
+          }
+        },
+        {
           "if": "count(sector) > 0",
           "then": "count(transaction/sector) < 1",
           "ruleInfo": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -656,7 +656,9 @@
     "no_more_than_one": {
       "cases": [
         {
-          "paths": ["default-aid-type[@vocabulary = '1' or not(@vocabulary)]"],
+          "paths": [
+            "default-aid-type[@vocabulary = '1' or @vocabulary = '' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "107.1.2",
             "severity": "warning",
@@ -666,7 +668,7 @@
         },
         {
           "paths": [
-            "transaction/aid-type[@vocabulary = '1' or not(@vocabulary)]"
+            "transaction/aid-type[@vocabulary = '1' or @vocabulary = '' or not(@vocabulary)]"
           ],
           "ruleInfo": {
             "id": "107.2.2",
@@ -682,7 +684,7 @@
         {
           "condition": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage) > 1",
           "paths": [
-            "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage"
+            "sector[@vocabulary = '1' or @vocabulary = '' or not(@vocabulary)]/@percentage"
           ],
           "sum": 100,
           "ruleInfo": {
@@ -1077,7 +1079,7 @@
     "atleast_one": {
       "cases": [
         {
-          "condition": "@vocabulary='1' or not(@vocabulary)",
+          "condition": "@vocabulary='1' or @vocabulary = '' or not(@vocabulary)",
           "paths": ["@significance"],
           "ruleInfo": {
             "id": "6.14.1",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -297,30 +297,6 @@
     "loop": {
       "cases": [
         {
-          "foreach": "description/@type",
-          "do": {
-            "if_then": {
-              "cases": [
-                {
-                  "if": "description[@type = '$1']/narrative",
-                  "then": "string(description[@type = '$1']//narrative) != ''",
-                  "paths": ["description[@type = '$1']/narrative"],
-                  "ruleInfo": {
-                    "id": "4.4.1",
-                    "severity": "error",
-                    "category": "information",
-                    "message": "The description must contain narrative content.",
-                    "link": {
-                      "path": "activity-standard/iati-activities/iati-activity/title/"
-                    }
-                  }
-                }
-              ]
-            }
-          },
-          "subs": ["if", "then", "paths"]
-        },
-        {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
           "do": {
             "strict_sum": {
@@ -698,34 +674,6 @@
     },
     "if_then": {
       "cases": [
-        {
-          "if": "title/narrative",
-          "then": "string(title//narrative) != ''",
-          "paths": ["title/narrative"],
-          "ruleInfo": {
-            "id": "4.3.1",
-            "severity": "error",
-            "category": "information",
-            "message": "The title must contain narrative content.",
-            "link": {
-              "path": "activity-standard/iati-activities/iati-activity/title/"
-            }
-          }
-        },
-        {
-          "if": "count(description[not(@type) or @type = '']/narrative) > 0",
-          "then": "string(description[not(@type) or @type = '']//narrative) != ''",
-          "paths": ["description[not(@type) or @type = '']/narrative"],
-          "ruleInfo": {
-            "id": "4.4.1",
-            "severity": "error",
-            "category": "information",
-            "message": "The description must contain narrative content.",
-            "link": {
-              "path": "activity-standard/iati-activities/iati-activity/title/"
-            }
-          }
-        },
         {
           "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
           "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])",
@@ -1801,6 +1749,42 @@
             "message": "The actual value should be omitted for qualitative indicator measures.",
             "link": {
               "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/actual/"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "//title": {
+    "atleast_one": {
+      "cases": [
+        {
+          "paths": ["narrative/text()"],
+          "ruleInfo": {
+            "id": "4.3.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The title must contain narrative content.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/title/"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "//description": {
+    "atleast_one": {
+      "cases": [
+        {
+          "paths": ["narrative/text()"],
+          "ruleInfo": {
+            "id": "4.4.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The description must contain narrative content.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/description/"
             }
           }
         }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1118,20 +1118,6 @@
           }
         }
       ]
-    },
-    "time_limit": {
-      "cases": [
-        {
-          "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date",
-          "ruleInfo": {
-            "id": "7.5.3",
-            "severity": "error",
-            "category": "financial",
-            "message": "Budget Period must not be longer than one year."
-          }
-        }
-      ]
     }
   },
   "//budget": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -345,7 +345,7 @@
             "strict_sum": {
               "cases": [
                 {
-                  "condition": "count(recipient-region[@vocabulary = '$1']) > 1",
+                  "condition": "count(recipient-region[@vocabulary = '$1']) + count(recipient-country) > 1",
                   "paths": [
                     "recipient-region[@vocabulary = '$1']/@percentage",
                     "recipient-country/@percentage"

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -674,6 +674,16 @@
           }
         },
         {
+          "if": "count(transaction/aid-type[not(@vocabulary='')]) + count(transaction/aid-type[not(@vocabulary='1')]) > 0",
+          "then": "count(transaction/aid-type[@vocabulary='']) + count(transaction/aid-type[@vocabulary='1']) + count(default-aid-type[not(@vocabulary)]) > 0",
+          "ruleInfo": {
+            "id": "107.2.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The transaction should also contain a code from the OECD DAC aid type vocabulary."
+          }
+        },
+        {
           "if": "count(sector) > 0",
           "then": "count(transaction/sector) < 1",
           "ruleInfo": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -313,7 +313,7 @@
                     "id": "3.4.1",
                     "severity": "error",
                     "category": "geo",
-                    "message": "Percentage values for recipient countries or regions, must add up to 100%."
+                    "message": "When multiple recipient countries or regions are declared, each must have a percentage."
                   }
                 }
               ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -580,7 +580,10 @@
             "id": "107.1.2",
             "severity": "warning",
             "category": "financial",
-            "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+            "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+            }
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -38,7 +38,7 @@
         },
         {
           "idCondition": "NOT_EXISTING_ORG_ID",
-          "prefix": "ORG-ID-PREFIX",
+          "prefix": ["ORG-ID-PREFIX"],
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.14.8",
@@ -482,9 +482,7 @@
               "cases": [
                 {
                   "if": "count(sector[@vocabulary = '$1']) > 1",
-                  "then": [
-                    "count(sector[@vocabulary = '$1']) = count(sector[@vocabulary = '$1']/@percentage)"
-                  ],
+                  "then": "count(sector[@vocabulary = '$1']) = count(sector[@vocabulary = '$1']/@percentage)",
                   "paths": ["sector[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "2.1.1",
@@ -509,7 +507,7 @@
                   "paths": ["sector[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "2.1.4",
-                    "severity": "",
+                    "severity": "error",
                     "category": "classifications",
                     "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
                   }
@@ -1003,7 +1001,7 @@
       "cases": [
         {
           "idCondition": "NOT_EXISTING_ORG_ID",
-          "prefix": "ORG-ID-PREFIX",
+          "prefix": ["ORG-ID-PREFIX"],
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.18.8",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -414,6 +414,26 @@
     "loop": {
       "cases": [
         {
+          "foreach": "description/@type",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "description[@type = '$1']/narrative",
+                  "then": "string(description[@type = '$1']//narrative) != ''",
+                  "ruleInfo": {
+                    "id": "4.4.1",
+                    "severity": "error",
+                    "category": "information",
+                    "message": "The description must contain narrative content."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
+        },
+        {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
           "do": {
             "strict_sum": {
@@ -716,6 +736,26 @@
     },
     "if_then": {
       "cases": [
+        {
+          "if": "title/narrative",
+          "then": "string(title//narrative) != ''",
+          "ruleInfo": {
+            "id": "4.3.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The title must contain narrative content."
+          }
+        },
+        {
+          "if": "count(description[not(@type) or @type = '']/narrative) > 0",
+          "then": "string(description[not(@type) or @type = '']//narrative) != ''",
+          "ruleInfo": {
+            "id": "4.4.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The description must contain narrative content."
+          }
+        },
         {
           "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
           "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -728,7 +728,7 @@
         },
         {
           "if": "count(sector[not(@vocabulary='')]) + count(sector[not(@vocabulary='1')]) > 0",
-          "then": "count(sector[@vocabulary='']) + count(sector[@vocabulary='1']) + count(sector[not(@vocabulary)]) > 0",
+          "then": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 0",
           "ruleInfo": {
             "id": "102.1.1",
             "severity": "warning",
@@ -737,8 +737,8 @@
           }
         },
         {
-          "if": "count(sector[@vocabulary='']) + count(sector[@vocabulary='1']) + count(sector[not(@vocabulary)]) > 1",
-          "then": "count(sector[@vocabulary='']) + count(sector[@vocabulary='1']) + count(sector[not(@vocabulary)]) = count(sector[@vocabulary='']/@percentage) + count(sector[@vocabulary='1']/@percentage) + count(sector[not(@vocabulary)]/@percentage)",
+          "if": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 1",
+          "then": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) = count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage)",
           "ruleInfo": {
             "id": "2.1.1",
             "severity": "error",
@@ -758,7 +758,7 @@
         },
         {
           "if": "count(default-aid-type[not(@vocabulary='')]) + count(default-aid-type[not(@vocabulary='1')]) > 0",
-          "then": "count(default-aid-type[@vocabulary='']) + count(default-aid-type[@vocabulary='1']) + count(default-aid-type[not(@vocabulary)]) > 0",
+          "then": "count(default-aid-type[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 0",
           "ruleInfo": {
             "id": "107.1.1",
             "severity": "warning",
@@ -768,7 +768,7 @@
         },
         {
           "if": "count(transaction/aid-type[not(@vocabulary='')]) + count(transaction/aid-type[not(@vocabulary='1')]) > 0",
-          "then": "count(transaction/aid-type[@vocabulary='']) + count(transaction/aid-type[@vocabulary='1']) + count(default-aid-type[not(@vocabulary)]) > 0",
+          "then": "count(transaction/aid-type[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 0",
           "ruleInfo": {
             "id": "107.2.1",
             "severity": "warning",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -37,6 +37,7 @@
           }
         },
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "prefix": "ORG-ID-PREFIX",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
@@ -184,6 +185,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID_PREFIX",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["iati-identifier"],
           "ruleInfo": {
@@ -194,6 +196,7 @@
           }
         },
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
@@ -795,6 +798,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {
@@ -824,6 +828,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {
@@ -897,6 +902,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {
@@ -939,6 +945,7 @@
     "startswith": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "prefix": "ORG-ID-PREFIX",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
@@ -953,6 +960,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["organisation-identifier"],
           "ruleInfo": {
@@ -963,6 +971,7 @@
           }
         },
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
@@ -1060,6 +1069,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -445,6 +445,26 @@
         {
           "foreach": "recipient-region/@vocabulary",
           "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(recipient-region[@vocabulary = '$1']) > 1",
+                  "then": "count(recipient-region[@vocabulary = '$1']) = count(recipient-region[@vocabulary = '$1']/@percentage)",
+                  "ruleInfo": {
+                    "id": "3.4.1",
+                    "severity": "error",
+                    "category": "geo",
+                    "message": "Percentage values for recipient countries or regions, must add up to 100%."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
+        },
+        {
+          "foreach": "recipient-region/@vocabulary",
+          "do": {
             "strict_sum": {
               "cases": [
                 {
@@ -843,6 +863,16 @@
             "severity": "error",
             "category": "financial",
             "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
+          }
+        },
+        {
+          "if": "count(recipient-country) > 0",
+          "then": "count(recipient-country) = count(recipient-country/@percentage)",
+          "ruleInfo": {
+            "id": "3.4.1",
+            "severity": "error",
+            "category": "geo",
+            "message": "When multiple recipient countries or regions are declared, each must have a percentage."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1,5 +1,18 @@
 {
   "//iati-activity": {
+    "unique": {
+      "cases": [
+        {
+          "paths": ["reporting-org/@ref", "iati-identifier"],
+          "ruleInfo": {
+            "id": "1.1.3",
+            "severity": "error",
+            "category": "identifiers",
+            "message": "The activity identifier must be different to the organisation identifier of the reporting organisation."
+          }
+        }
+      ]
+    },
     "startsWith": {
       "cases": [
         {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -41,7 +41,15 @@
     "atleast_one": {
       "cases": [
         { "paths": ["activity-date[@type='1' or @type='2']"] },
-        { "paths": ["sector", "transaction/sector"] }
+        {
+          "paths": ["sector", "transaction/sector"],
+          "ruleInfo": {
+            "id": "6.2.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "Each activity must have a specified sector, either at activity level OR for all transactions."
+          }
+        }
       ]
     },
     "one_or_all": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -8,7 +8,16 @@
     },
     "one_or_all": {
       "cases": [
-        { "one": "@xml:lang", "all": "lang" },
+        {
+          "one": "@xml:lang",
+          "all": "lang",
+          "ruleInfo": {
+            "id": "4.1.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The activity should specify a default language OR the language must be specified for each narrative element."
+          }
+        },
         { "one": "sector", "all": "sector" },
         { "one": "@default-currency", "all": "currency" }
       ]
@@ -25,7 +34,17 @@
       ]
     },
     "date_now": {
-      "cases": [{ "date": "@last-updated-datetime" }]
+      "cases": [
+        {
+          "date": "@last-updated-datetime",
+          "ruleInfo": {
+            "id": "11.1.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The last updated datetime of the activity must not be in the future."
+          }
+        }
+      ]
     },
     "date_order": {
       "cases": [
@@ -37,8 +56,22 @@
           "less": "activity-date[@type='2']/@iso-date",
           "more": "activity-date[@type='4']/@iso-date"
         },
-        { "less": "activity-date[@type='2']/@iso-date", "more": "NOW" },
-        { "less": "activity-date[@type='4']/@iso-date", "more": "NOW" }
+        {
+          "less": "activity-date[@type='2']/@iso-date",
+          "more": "NOW"
+        },
+        {
+          "less": "activity-date[@type='4']/@iso-date",
+          "more": "NOW"
+        },
+        {
+          "less": "transaction/transaction-date/@iso-date",
+          "more": "NOW"
+        },
+        {
+          "less": "transaction/value/@value-date",
+          "more": "NOW"
+        }
       ]
     },
     "regex_matches": {
@@ -52,17 +85,6 @@
             "transaction/provider-org/@ref",
             "transaction/receiver-org/@ref"
           ]
-        }
-      ]
-    },
-    "sum": {
-      "cases": [
-        {
-          "paths": [
-            "recipient-country/@percentage",
-            "recipient-region/@percentage"
-          ],
-          "sum": 100
         }
       ]
     },
@@ -81,6 +103,23 @@
             }
           },
           "subs": ["paths"]
+        },
+        {
+          "foreach": "recipient-region/@vocabulary",
+          "do": {
+            "strict_sum": {
+              "cases": [
+                {
+                  "paths": [
+                    "recipient-region[@vocabulary = '$1']/@percentage",
+                    "recipient-country/@percentage"
+                  ],
+                  "sum": 100
+                }
+              ]
+            }
+          },
+          "subs": ["paths"]
         }
       ]
     },
@@ -90,6 +129,11 @@
           "paths": [
             "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage"
           ],
+          "sum": 100
+        },
+        {
+          "condition": "not(recipient-region)",
+          "paths": ["recipient-country/@percentage"],
           "sum": 100
         }
       ]
@@ -127,14 +171,30 @@
       "cases": [
         {
           "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
-          "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])"
+          "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])",
+          "ruleInfo": {
+            "id": "2.2.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When using a reporting organisation sector code (vocabulary 98 or 99), it must include a narrative."
+          }
         }
       ]
     }
   },
   "//iati-activity/other-identifier/owner-org": {
     "atleast_one": {
-      "cases": [{ "paths": ["@ref", "narrative"] }]
+      "cases": [
+        {
+          "paths": ["@ref", "narrative"],
+          "ruleInfo": {
+            "id": "6.8.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The owner organisation must have an identifier or a narrative."
+          }
+        }
+      ]
     }
   },
   "//iati-activity/transaction/provider-org": {
@@ -166,7 +226,17 @@
       "cases": [
         {
           "regex": "[^\\/\\&\\|\\?]+",
-          "paths": ["reporting-org/@ref", "organisation-identifier"]
+          "paths": ["organisation-identifier"]
+        },
+        {
+          "regex": "[^\\/\\&\\|\\?]+",
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.18.13",
+            "severity": "warning",
+            "category": "information",
+            "message": "The {{matchedPathValue}} must not contain any of the symbols /, &, | or ?."
+          }
         }
       ]
     },
@@ -175,7 +245,16 @@
     },
     "one_or_all": {
       "cases": [
-        { "one": "@xml:lang", "all": "lang" },
+        {
+          "one": "@xml:lang",
+          "all": "lang",
+          "ruleInfo": {
+            "id": "4.5.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The organisation should specify a default language, or the language should be specified for each narrative element."
+          }
+        },
         { "one": "@default-currency", "all": "currency" }
       ]
     }
@@ -183,14 +262,6 @@
   "//participating-org": {
     "atleast_one": {
       "cases": [{ "paths": ["@ref", "narrative"] }]
-    }
-  },
-  "//transaction": {
-    "date_order": {
-      "cases": [
-        { "less": "transaction-date/@iso-date", "more": "NOW" },
-        { "less": "value/@value-date", "more": "NOW" }
-      ]
     }
   },
   "//planned-disbursement": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1,5 +1,5 @@
 {
-  "//iati-activity": {
+  "/iati-activities/iati-activity": {
     "unique": {
       "cases": [
         {
@@ -877,7 +877,7 @@
       ]
     }
   },
-  "//transaction": {
+  "/iati-activities/iati-activity/transaction": {
     "no_more_than_one": {
       "cases": [
         {
@@ -923,7 +923,7 @@
       ]
     }
   },
-  "//iati-activity/other-identifier/owner-org": {
+  "/iati-activities/iati-activity/other-identifier/owner-org": {
     "atleast_one": {
       "cases": [
         {
@@ -969,7 +969,7 @@
       ]
     }
   },
-  "//provider-org": {
+  "/iati-activities/iati-activity/transaction/provider-org | /iati-activities/iati-activity/planned-disbursement/provider-org": {
     "atleast_one": {
       "cases": [
         {
@@ -1024,7 +1024,7 @@
       ]
     }
   },
-  "//receiver-org": {
+  "/iati-activities/iati-activity/transaction/receiver-org | /iati-activities/iati-activity/planned-disbursement/receiver-org": {
     "atleast_one": {
       "cases": [
         {
@@ -1079,7 +1079,7 @@
       ]
     }
   },
-  "//policy-marker": {
+  "/iati-activities/iati-activity/policy-marker": {
     "atleast_one": {
       "cases": [
         {
@@ -1111,7 +1111,7 @@
       ]
     }
   },
-  "//iati-organisation": {
+  "/iati-organisations/iati-organisation": {
     "startswith": {
       "cases": [
         {
@@ -1242,7 +1242,7 @@
       ]
     }
   },
-  "//participating-org": {
+  "/iati-activities/iati-activity/participating-org": {
     "atleast_one": {
       "cases": [
         {
@@ -1297,7 +1297,7 @@
       ]
     }
   },
-  "//planned-disbursement": {
+  "/iati-activities/iati-activity/planned-disbursement": {
     "date_order": {
       "cases": [
         {
@@ -1316,43 +1316,7 @@
       ]
     }
   },
-  "//budget": {
-    "date_order": {
-      "cases": [
-        {
-          "less": "period-start/@iso-date",
-          "more": "period-end/@iso-date",
-          "ruleInfo": {
-            "id": "8.6.3",
-            "severity": "error",
-            "category": "financial",
-            "message": "The start of the period must be before the end of the period.",
-            "link": {
-              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
-            }
-          }
-        }
-      ]
-    },
-    "time_limit": {
-      "cases": [
-        {
-          "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date",
-          "ruleInfo": {
-            "id": "7.5.3",
-            "severity": "error",
-            "category": "financial",
-            "message": "Budget Period must not be longer than one year.",
-            "link": {
-              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
-            }
-          }
-        }
-      ]
-    }
-  },
-  "//total-budget": {
+  "/iati-activities/iati-activity/budget": {
     "date_order": {
       "cases": [
         {
@@ -1388,7 +1352,43 @@
       ]
     }
   },
-  "//recipient-country-budget": {
+  "/iati-organisations/iati-organisation/total-budget": {
+    "date_order": {
+      "cases": [
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
+          }
+        }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "/iati-organisations/iati-organisation/recipient-country-budget": {
     "date_order": {
       "cases": [
         {
@@ -1442,7 +1442,7 @@
       ]
     }
   },
-  "//recipient-org-budget": {
+  "/iati-organisations/iati-organisation/recipient-org-budget": {
     "date_order": {
       "cases": [
         {
@@ -1478,7 +1478,7 @@
       ]
     }
   },
-  "//recipient-region-budget": {
+  "/iati-organisations/iati-organisation/recipient-region-budget": {
     "date_order": {
       "cases": [
         {
@@ -1514,7 +1514,7 @@
       ]
     }
   },
-  "//result/indicator": {
+  "/iati-activities/iati-activity/result/indicator": {
     "no_more_than_one": {
       "cases": [
         {
@@ -1532,7 +1532,7 @@
       ]
     }
   },
-  "//result/indicator/period": {
+  "/iati-activities/iati-activity/result/indicator/period": {
     "date_order": {
       "cases": [
         {
@@ -1551,7 +1551,7 @@
       ]
     }
   },
-  "//total-expenditure": {
+  "/iati-organisations/iati-organisation/total-expenditure": {
     "time_limit": {
       "cases": [
         {
@@ -1587,7 +1587,7 @@
       ]
     }
   },
-  "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/baseline": {
+  "/iati-activities/iati-activity/result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/baseline": {
     "atleast_one": {
       "cases": [
         {
@@ -1623,7 +1623,7 @@
       ]
     }
   },
-  "//result/indicator[@measure='5']/baseline": {
+  "/iati-activities/iati-activity/result/indicator[@measure='5']/baseline": {
     "if_then": {
       "cases": [
         {
@@ -1643,7 +1643,7 @@
       ]
     }
   },
-  "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/target": {
+  "/iati-activities/iati-activity/result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/target": {
     "atleast_one": {
       "cases": [
         {
@@ -1679,7 +1679,7 @@
       ]
     }
   },
-  "//result/indicator[@measure='5']/period/target": {
+  "/iati-activities/iati-activity/result/indicator[@measure='5']/period/target": {
     "if_then": {
       "cases": [
         {
@@ -1699,7 +1699,7 @@
       ]
     }
   },
-  "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/actual": {
+  "/iati-activities/iati-activity/result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/actual": {
     "atleast_one": {
       "cases": [
         {
@@ -1735,7 +1735,7 @@
       ]
     }
   },
-  "//result/indicator[@measure='5']/period/actual": {
+  "/iati-activities/iati-activity/result/indicator[@measure='5']/period/actual": {
     "if_then": {
       "cases": [
         {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -509,7 +509,10 @@
                     "id": "107.1.2",
                     "severity": "warning",
                     "category": "financial",
-                    "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+                    "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+                    }
                   }
                 }
               ]
@@ -799,7 +802,10 @@
             "id": "107.1.1",
             "severity": "warning",
             "category": "information",
-            "message": "The activity should also declare an aid type code from aid type vocabulary 1 - OECD DAC."
+            "message": "The activity should also declare an aid type code from aid type vocabulary 1 - OECD DAC.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+            }
           }
         },
         {
@@ -814,7 +820,10 @@
             "id": "107.2.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The transaction should also contain a code from the OECD DAC aid type vocabulary."
+            "message": "The transaction should also contain a code from the OECD DAC aid type vocabulary.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+            }
           }
         },
         {
@@ -928,7 +937,10 @@
             "id": "107.2.2",
             "severity": "warning",
             "category": "financial",
-            "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+            "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+            }
           }
         }
       ]
@@ -946,7 +958,10 @@
                     "id": "107.2.2",
                     "severity": "warning",
                     "category": "financial",
-                    "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+                    "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+                    }
                   }
                 }
               ]
@@ -966,7 +981,10 @@
             "id": "6.8.1",
             "severity": "error",
             "category": "information",
-            "message": "The owner organisation must have an identifier or a narrative."
+            "message": "The owner organisation must have an identifier or a narrative.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/other-identifier/owner-org/narrative"
+            }
           }
         }
       ]
@@ -1009,7 +1027,10 @@
             "id": "6.9.1",
             "severity": "error",
             "category": "financial",
-            "message": "The provider organisation must have an organisation identifier or a narrative."
+            "message": "The provider organisation must have an organisation identifier or a narrative.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/transaction/provider-org/narrative/"
+            }
           }
         }
       ]
@@ -1061,7 +1082,10 @@
             "id": "6.9.2",
             "severity": "error",
             "category": "financial",
-            "message": "The receiver organisation must have an organisation identifier or a narrative."
+            "message": "The receiver organisation must have an organisation identifier or a narrative.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/transaction/receiver-org/narrative/"
+            }
           }
         }
       ]
@@ -1232,7 +1256,10 @@
             "id": "11.4.1",
             "severity": "error",
             "category": "information",
-            "message": "The last updated datetime of the organisation must not be in the future."
+            "message": "The last updated datetime of the organisation must not be in the future.",
+            "link": {
+              "path": "organisation-standard/iati-organisations/iati-organisation/"
+            }
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -24,6 +24,17 @@
             "category": "identifiers",
             "message": "The activity identifier should begin with the organisation identifier of the reporting organisation (or a previous version included in the other-identifier element)."
           }
+        },
+        {
+          "prefix": ["reporting-org/@ref", "other-identifier[@type='B1']/@ref"],
+          "separator": "-",
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.1.21",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The activity identifier should be your IATI Organisation Identifier followed by a unique string for the activity separated by a hyphen e.g. COH-1234-activity1"
+          }
         }
       ]
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -278,6 +278,55 @@
         }
       ]
     },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.3.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The iati-idenitifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.14.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting-org idenitifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["other-identifier[@type='B1']/@ref"],
+          "ruleInfo": {
+            "id": "1.16.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous reporting organisation identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["other-identifier[@type='A3']/@ref"],
+          "ruleInfo": {
+            "id": "1.6.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous activity identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["related-activity/@ref"],
+          "ruleInfo": {
+            "id": "1.7.1",
+            "severity": "warning",
+            "category": "relations",
+            "message": "The related activity identifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
+    },
     "loop": {
       "cases": [
         {
@@ -469,16 +518,73 @@
           }
         }
       ]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.11.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The owner organisation idenitifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
     }
   },
-  "//iati-activity/transaction/provider-org": {
+  "//provider-org": {
     "atleast_one": {
       "cases": [{ "paths": ["@ref", "narrative"] }]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.10.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider organisation idenitifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["@provider-activity-id"],
+          "ruleInfo": {
+            "id": "1.4.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider-org activity idenitifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
     }
   },
-  "//iati-activity/transaction/receiver-org": {
+  "//receiver-org": {
     "atleast_one": {
       "cases": [{ "paths": ["@ref", "narrative"] }]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.15.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver-org idenitifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["@receiver-activity-id"],
+          "ruleInfo": {
+            "id": "1.5.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver-org activity idenitifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
     }
   },
   "//policy-marker": {
@@ -560,6 +666,37 @@
         }
       ]
     },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["organisation-identifier"],
+          "ruleInfo": {
+            "id": "1.12.1",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The organisation-identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["recipient-org-budget/recipient-org/@ref"],
+          "ruleInfo": {
+            "id": "1.17.1",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The recipient organisation identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.18.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting-org identifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
+    },
     "date_now": {
       "cases": [{ "date": "@last-updated-datetime" }]
     },
@@ -582,6 +719,28 @@
   "//participating-org": {
     "atleast_one": {
       "cases": [{ "paths": ["@ref", "narrative"] }]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.8.1",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating-org identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["@activity-id"],
+          "ruleInfo": {
+            "id": "1.9.1",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating-org activity identifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
     }
   },
   "//planned-disbursement": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -3,7 +3,17 @@
     "atleast_one": {
       "cases": [
         { "paths": ["activity-date[@type='1' or @type='2']"] },
-        { "paths": ["sector", "transaction/sector"] }
+        { "paths": ["sector", "transaction/sector"] },
+        {
+          "if": "count(sector[not(@vocabulary='')]) + count(sector[not(@vocabulary='1')]) > 0",
+          "then": "count(sector[@vocabulary='']) + count(sector[@vocabulary='1']) + count(sector[not(@vocabulary)]) > 0",
+          "ruleInfo": {
+            "id": "102.1.1",
+            "severity": "warning",
+            "category": "information",
+            "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used."
+          }
+        }
       ]
     },
     "one_or_all": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1253,6 +1253,20 @@
           }
         }
       ]
+    },
+    "if_then": {
+      "cases": [
+        {
+          "if": "@value",
+          "then": "number(@value) = @value",
+          "ruleInfo": {
+            "id": "8.8.2",
+            "severity": "warning",
+            "category": "performance",
+            "message": "The baseline value should be a valid number for all non-qualitative measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+          }
+        }
+      ]
     }
   },
   "//result/indicator[@measure='5']/baseline": {
@@ -1284,6 +1298,20 @@
           }
         }
       ]
+    },
+    "if_then": {
+      "cases": [
+        {
+          "if": "@value",
+          "then": "number(@value) = @value",
+          "ruleInfo": {
+            "id": "8.9.2",
+            "severity": "warning",
+            "category": "performance",
+            "message": "The target value should be a valid number for all non-qualitative measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+          }
+        }
+      ]
     }
   },
   "//result/indicator[@measure='5']/period/target": {
@@ -1312,6 +1340,20 @@
             "severity": "error",
             "category": "performance",
             "message": "The actual must have a value when the indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+          }
+        }
+      ]
+    },
+    "if_then": {
+      "cases": [
+        {
+          "if": "@value",
+          "then": "number(@value) = @value",
+          "ruleInfo": {
+            "id": "8.10.2",
+            "severity": "warning",
+            "category": "performance",
+            "message": "The actual value should be a valid number for all non-qualitative indicator measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -447,25 +447,6 @@
           "subs": ["paths"]
         },
         {
-          "foreach": "transaction/aid-type[@vocabulary != 1]/@vocabulary",
-          "do": {
-            "no_more_than_one": {
-              "cases": [
-                {
-                  "paths": ["transaction/aid-type[@vocabulary = '$1']"],
-                  "ruleInfo": {
-                    "id": "107.2.2",
-                    "severity": "warning",
-                    "category": "financial",
-                    "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
-                  }
-                }
-              ]
-            }
-          },
-          "subs": ["paths"]
-        },
-        {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
           "do": {
             "if_then": {
@@ -520,17 +501,6 @@
             "severity": "warning",
             "category": "financial",
             "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
-          }
-        },
-        {
-          "paths": [
-            "transaction/aid-type[@vocabulary = '1' or @vocabulary = '' or not(@vocabulary)]"
-          ],
-          "ruleInfo": {
-            "id": "107.2.2",
-            "severity": "warning",
-            "category": "financial",
-            "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
           }
         }
       ]
@@ -809,6 +779,46 @@
             "category": "geo",
             "message": "When a single recipient country is declared, the percentage must either be omitted, or set to 100."
           }
+        }
+      ]
+    }
+  },
+  "//transaction": {
+    "no_more_than_one": {
+      "cases": [
+        {
+          "paths": [
+            "aid-type[@vocabulary = '1' or @vocabulary = '' or not(@vocabulary)]"
+          ],
+          "ruleInfo": {
+            "id": "107.2.2",
+            "severity": "warning",
+            "category": "financial",
+            "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+          }
+        }
+      ]
+    },
+    "loop": {
+      "cases": [
+        {
+          "foreach": "aid-type[@vocabulary != 1]/@vocabulary",
+          "do": {
+            "no_more_than_one": {
+              "cases": [
+                {
+                  "paths": ["aid-type[@vocabulary = '$1']"],
+                  "ruleInfo": {
+                    "id": "107.2.2",
+                    "severity": "warning",
+                    "category": "financial",
+                    "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["paths"]
         }
       ]
     }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -74,7 +74,16 @@
             "message": "If sector is declared at transaction level, a sector must be declared for all transactions."
           }
         },
-        { "one": "@default-currency", "all": "currency" }
+        {
+          "one": "@default-currency",
+          "all": "currency",
+          "ruleInfo": {
+            "id": "7.8.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The activity should specify a default currency OR the currency must be specified for each monetary value."
+          }
+        }
       ]
     },
     "only_one_of": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -166,7 +166,15 @@
     },
     "atleast_one": {
       "cases": [
-        { "paths": ["activity-date[@type='1' or @type='2']"] },
+        {
+          "paths": ["activity-date[@type='1' or @type='2']"],
+          "ruleInfo": {
+            "id": "6.11.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The activity must have a planned start date or an actual start date."
+          }
+        },
         {
           "paths": ["sector", "transaction/sector"],
           "ruleInfo": {
@@ -240,27 +248,63 @@
       "cases": [
         {
           "less": "activity-date[@type='1']/@iso-date",
-          "more": "activity-date[@type='3']/@iso-date"
+          "more": "activity-date[@type='3']/@iso-date",
+          "ruleInfo": {
+            "id": "11.1.2",
+            "severity": "error",
+            "category": "iati",
+            "message": "The planned start date of the activity must be before the planned end date."
+          }
         },
         {
           "less": "activity-date[@type='2']/@iso-date",
-          "more": "activity-date[@type='4']/@iso-date"
+          "more": "activity-date[@type='4']/@iso-date",
+          "ruleInfo": {
+            "id": "11.1.3",
+            "severity": "error",
+            "category": "iati",
+            "message": "The actual start date of the activity must be before the actual end date."
+          }
         },
         {
           "less": "activity-date[@type='2']/@iso-date",
-          "more": "NOW"
+          "more": "NOW",
+          "ruleInfo": {
+            "id": "11.1.4",
+            "severity": "error",
+            "category": "iati",
+            "message": "The actual start date of the activity must not be in the future."
+          }
         },
         {
           "less": "activity-date[@type='4']/@iso-date",
-          "more": "NOW"
+          "more": "NOW",
+          "ruleInfo": {
+            "id": "11.1.5",
+            "severity": "error",
+            "category": "iati",
+            "message": "The actual end date of the activity must not be in the future."
+          }
         },
         {
           "less": "transaction/transaction-date/@iso-date",
-          "more": "NOW"
+          "more": "NOW",
+          "ruleInfo": {
+            "id": "11.2.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The transaction date must not be in the future."
+          }
         },
         {
           "less": "transaction/value/@value-date",
-          "more": "NOW"
+          "more": "NOW",
+          "ruleInfo": {
+            "id": "11.2.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "The transaction value date must not be in the future."
+          }
         }
       ]
     },
@@ -589,7 +633,17 @@
   },
   "//provider-org": {
     "atleast_one": {
-      "cases": [{ "paths": ["@ref", "narrative"] }]
+      "cases": [
+        {
+          "paths": ["@ref", "narrative"],
+          "ruleInfo": {
+            "id": "6.9.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The provider organisation must have an organisation identifier or a narrative."
+          }
+        }
+      ]
     },
     "regex_matches": {
       "cases": [
@@ -640,7 +694,17 @@
   },
   "//receiver-org": {
     "atleast_one": {
-      "cases": [{ "paths": ["@ref", "narrative"] }]
+      "cases": [
+        {
+          "paths": ["@ref", "narrative"],
+          "ruleInfo": {
+            "id": "6.9.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "The receiver organisation must have an organisation identifier or a narrative."
+          }
+        }
+      ]
     },
     "no_spaces": {
       "cases": [
@@ -816,7 +880,17 @@
       ]
     },
     "date_now": {
-      "cases": [{ "date": "@last-updated-datetime" }]
+      "cases": [
+        {
+          "date": "@last-updated-datetime",
+          "ruleInfo": {
+            "id": "11.4.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The last updated datetime of the organisation must not be in the future."
+          }
+        }
+      ]
     },
     "one_or_all": {
       "cases": [
@@ -836,7 +910,17 @@
   },
   "//participating-org": {
     "atleast_one": {
-      "cases": [{ "paths": ["@ref", "narrative"] }]
+      "cases": [
+        {
+          "paths": ["@ref", "narrative"],
+          "ruleInfo": {
+            "id": "6.10.1",
+            "severity": "error",
+            "category": "participating",
+            "message": "The participating organisation must have an identifier or a narrative."
+          }
+        }
+      ]
     },
     "regex_matches": {
       "cases": [
@@ -1010,7 +1094,13 @@
         {
           "date": "budget-line/value/@value-date",
           "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date"
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "11.3.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The budget line value date must be within the budget period."
+          }
         }
       ]
     },
@@ -1091,13 +1181,32 @@
   },
   "//result/indicator": {
     "no_more_than_one": {
-      "cases": [{ "paths": ["reference[1]", "../reference[1]"] }]
+      "cases": [
+        {
+          "paths": ["reference[1]", "../reference[1]"],
+          "ruleInfo": {
+            "id": "8.11.1",
+            "severity": "error",
+            "category": "performance",
+            "message": "A reference code must only be declared at result OR result indicator level."
+          }
+        }
+      ]
     }
   },
   "//result/indicator/period": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.1",
+            "severity": "error",
+            "category": "performance",
+            "message": "The start date of the indicator period must be before the end date of the indicator period."
+          }
+        }
       ]
     }
   },
@@ -1133,7 +1242,17 @@
   },
   "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/baseline": {
     "atleast_one": {
-      "cases": [{ "paths": ["@value"] }]
+      "cases": [
+        {
+          "paths": ["@value"],
+          "ruleInfo": {
+            "id": "8.8.1",
+            "severity": "error",
+            "category": "performance",
+            "message": "The baseline must have a value when the indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+          }
+        }
+      ]
     }
   },
   "//result/indicator[@measure='5']/baseline": {
@@ -1154,7 +1273,17 @@
   },
   "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/target": {
     "atleast_one": {
-      "cases": [{ "paths": ["@value"] }]
+      "cases": [
+        {
+          "paths": ["@value"],
+          "ruleInfo": {
+            "id": "8.9.1",
+            "severity": "error",
+            "category": "performance",
+            "message": "The target must have a value when indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+          }
+        }
+      ]
     }
   },
   "//result/indicator[@measure='5']/period/target": {
@@ -1175,7 +1304,17 @@
   },
   "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/actual": {
     "atleast_one": {
-      "cases": [{ "paths": ["@value"] }]
+      "cases": [
+        {
+          "paths": ["@value"],
+          "ruleInfo": {
+            "id": "8.10.1",
+            "severity": "error",
+            "category": "performance",
+            "message": "The actual must have a value when the indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+          }
+        }
+      ]
     }
   },
   "//result/indicator[@measure='5']/period/actual": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -37,7 +37,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["iati-identifier"],
           "ruleInfo": {
             "id": "1.3.8",
@@ -47,7 +47,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["planned-disbursement/provider-org/@ref"],
           "ruleInfo": {
             "id": "1.10.8",
@@ -57,7 +57,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["other-identifier/owner-org/@ref"],
           "ruleInfo": {
             "id": "1.11.8",
@@ -67,7 +67,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.14.8",
@@ -77,7 +77,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["planned-disbursement/receiver-org/@ref"],
           "ruleInfo": {
             "id": "1.15.8",
@@ -87,7 +87,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["other-identifier[@type='B1']/@ref"],
           "ruleInfo": {
             "id": "1.16.8",
@@ -97,7 +97,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["other-identifier[@type='A3']/@ref"],
           "ruleInfo": {
             "id": "1.6.8",
@@ -107,7 +107,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": [
             "planned-disbursement/provider-org/@provider-activity-id",
             "transaction/provider-org/@provider-activity-id"
@@ -120,7 +120,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": [
             "planned-disbursement/receiver-org/@receiver-activity-id",
             "/transaction/receiver-org/@receiver-activity-id"
@@ -133,7 +133,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["related-activity/@ref"],
           "ruleInfo": {
             "id": "1.7.8",
@@ -143,7 +143,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["participating-org/@ref"],
           "ruleInfo": {
             "id": "1.8.8",
@@ -153,7 +153,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["participating-org/@activity-id"],
           "ruleInfo": {
             "id": "1.9.8",
@@ -1105,7 +1105,7 @@
     "startswith": {
       "cases": [
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["organisation-identifier"],
           "ruleInfo": {
             "id": "1.12.8",
@@ -1115,7 +1115,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["recipient-org-budget/recipient-org/@ref"],
           "ruleInfo": {
             "id": "1.17.8",
@@ -1125,7 +1125,7 @@
           }
         },
         {
-          "prefix": "ORG-ID",
+          "prefix": "ORG-ID-PREFIX",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.18.8",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -626,6 +626,21 @@
       ]
     }
   },
+  "//budget/value": {
+    "atleast_one": {
+      "cases": [
+        {
+          "paths": ["@value-date"],
+          "ruleInfo": {
+            "id": "7.5.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Value must include a Value Date."
+          }
+        }
+      ]
+    }
+  },
   "//total-budget": {
     "date_order": {
       "cases": [

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -252,12 +252,24 @@
         {
           "paths": ["capital-spend/@percentage"],
           "min": 0.0,
-          "max": 100.0
+          "max": 100.0,
+          "ruleInfo": {
+            "id": "12.2.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
         },
         {
           "paths": ["country-budget-items/budget-item/@percentage"],
           "min": 0.0,
-          "max": 100.0
+          "max": 100.0,
+          "ruleInfo": {
+            "id": "12.2.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
         }
       ]
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1205,21 +1205,6 @@
       ]
     }
   },
-  "//budget/value": {
-    "atleast_one": {
-      "cases": [
-        {
-          "paths": ["@value-date"],
-          "ruleInfo": {
-            "id": "7.5.2",
-            "severity": "error",
-            "category": "financial",
-            "message": "Budget Value must include a Value Date."
-          }
-        }
-      ]
-    }
-  },
   "//total-budget": {
     "date_order": {
       "cases": [

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1137,29 +1137,29 @@
           }
         }
       ]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.8.1",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating-org identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["@activity-id"],
+          "ruleInfo": {
+            "id": "1.9.1",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating-org activity identifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
     }
-  },
-  "no_spaces": {
-    "cases": [
-      {
-        "paths": ["@ref"],
-        "ruleInfo": {
-          "id": "1.8.1",
-          "severity": "warning",
-          "category": "participating",
-          "message": "The participating-org identifier should not start or end with spaces or newlines."
-        }
-      },
-      {
-        "paths": ["@activity-id"],
-        "ruleInfo": {
-          "id": "1.9.1",
-          "severity": "warning",
-          "category": "participating",
-          "message": "The participating-org activity identifier should not start or end with spaces or newlines."
-        }
-      }
-    ]
   },
   "//planned-disbursement": {
     "date_order": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1226,7 +1226,16 @@
             "message": "The organisation should specify a default language, or the language should be specified for each narrative element."
           }
         },
-        { "one": "@default-currency", "all": "currency" }
+        {
+          "one": "@default-currency",
+          "all": "currency",
+          "ruleInfo": {
+            "id": "7.8.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "The financial value must have a specified currency, or the organisation must declare a default currency."
+          }
+        }
       ]
     }
   },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -589,6 +589,20 @@
       "cases": [
         { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
       ]
+    },
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
+      ]
     }
   },
   "//budget": {
@@ -599,7 +613,16 @@
     },
     "time_limit": {
       "cases": [
-        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
       ]
     }
   },
@@ -611,7 +634,16 @@
     },
     "time_limit": {
       "cases": [
-        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
       ]
     }
   },
@@ -632,7 +664,16 @@
     },
     "time_limit": {
       "cases": [
-        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
       ]
     }
   },
@@ -644,7 +685,16 @@
     },
     "time_limit": {
       "cases": [
-        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
       ]
     }
   },
@@ -656,7 +706,16 @@
     },
     "time_limit": {
       "cases": [
-        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
       ]
     }
   },
@@ -675,7 +734,16 @@
   "//total-expenditure": {
     "time_limit": {
       "cases": [
-        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
       ]
     },
     "date_order": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -558,6 +558,28 @@
             }
           },
           "subs": ["paths"]
+        },
+        {
+          "foreach": "sector[@vocabulary != '1']/@vocabulary",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(sector[@vocabulary = '$1']) > 1",
+                  "then": [
+                    "count(sector[@vocabulary = '$1']) = count(sector[@vocabulary = '$1']/@percentage)"
+                  ],
+                  "ruleInfo": {
+                    "id": "2.1.1",
+                    "severity": "error",
+                    "category": "classifications",
+                    "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
         }
       ]
     },
@@ -691,6 +713,16 @@
             "severity": "warning",
             "category": "information",
             "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used."
+          }
+        },
+        {
+          "if": "count(sector[@vocabulary='']) + count(sector[@vocabulary='1']) + count(sector[not(@vocabulary)]) > 1",
+          "then": "count(sector[@vocabulary='']) + count(sector[@vocabulary='1']) + count(sector[not(@vocabulary)]) = count(sector[@vocabulary='']/@percentage) + count(sector[@vocabulary='1']/@percentage) + count(sector[not(@vocabulary)]/@percentage)",
+          "ruleInfo": {
+            "id": "2.1.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
           }
         },
         {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1,5 +1,19 @@
 {
   "//iati-activity": {
+    "startsWith": {
+      "cases": [
+        {
+          "prefix": ["reporting-org/@ref", "other-identifier[@type='B1']/@ref"],
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.1.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The activity identifier should begin with the organisation identifier of the reporting organisation (or a previous version included in the other-identifier element)."
+          }
+        }
+      ]
+    },
     "atleast_one": {
       "cases": [
         { "paths": ["activity-date[@type='1' or @type='2']"] },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -203,7 +203,7 @@
             "id": "1.14.13",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -225,7 +225,7 @@
             "id": "1.14.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org idenitifier should not start or end with spaces or newlines."
+            "message": "The reporting-org identifier should not start or end with spaces or newlines."
           }
         },
         {
@@ -845,7 +845,7 @@
             "id": "1.11.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The owner organisation idenitifier should not start or end with spaces or newlines."
+            "message": "The owner organisation identifier should not start or end with spaces or newlines."
           }
         }
       ]
@@ -860,7 +860,7 @@
             "id": "1.11.13",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The owner organisation idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The owner organisation identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -890,7 +890,7 @@
             "id": "1.10.13",
             "severity": "warning",
             "category": "financial",
-            "message": "The provider organisation idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The provider organisation identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -903,7 +903,7 @@
             "id": "1.10.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The provider organisation idenitifier should not start or end with spaces or newlines."
+            "message": "The provider organisation identifier should not start or end with spaces or newlines."
           }
         },
         {
@@ -912,7 +912,7 @@
             "id": "1.4.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The provider-org activity idenitifier should not start or end with spaces or newlines."
+            "message": "The provider-org activity identifier should not start or end with spaces or newlines."
           }
         }
       ]
@@ -940,7 +940,7 @@
             "id": "1.15.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The receiver-org idenitifier should not start or end with spaces or newlines."
+            "message": "The receiver-org identifier should not start or end with spaces or newlines."
           }
         },
         {
@@ -949,7 +949,7 @@
             "id": "1.5.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The receiver-org activity idenitifier should not start or end with spaces or newlines."
+            "message": "The receiver-org activity identifier should not start or end with spaces or newlines."
           }
         }
       ]
@@ -964,7 +964,7 @@
             "id": "1.15.13",
             "severity": "warning",
             "category": "financial",
-            "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The receiver-org identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -1022,7 +1022,7 @@
             "id": "1.12.13",
             "severity": "warning",
             "category": "organisation",
-            "message": "The organisation-idenitifer must not contain any of the symbols /, &, | or ?."
+            "message": "The organisation-identifier must not contain any of the symbols /, &, | or ?."
           }
         },
         {
@@ -1131,7 +1131,7 @@
             "id": "1.8.13",
             "severity": "warning",
             "category": "participating",
-            "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The receiver-org identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -587,7 +587,16 @@
   "//planned-disbursement": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "time_limit": {
@@ -608,7 +617,16 @@
   "//budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "time_limit": {
@@ -644,7 +662,16 @@
   "//total-budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "time_limit": {
@@ -665,7 +692,16 @@
   "//recipient-country-budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "between_dates": {
@@ -695,7 +731,16 @@
   "//recipient-org-budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "time_limit": {
@@ -716,7 +761,16 @@
   "//recipient-region-budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "time_limit": {
@@ -763,7 +817,16 @@
     },
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     }
   },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -220,17 +220,6 @@
         }
       ]
     },
-    "only_one_of": {
-      "cases": [
-        {
-          "excluded": ["recipient-region", "recipient-country"],
-          "paths": [
-            "transaction/recipient-country",
-            "transaction/recipient-region"
-          ]
-        }
-      ]
-    },
     "date_now": {
       "cases": [
         {
@@ -824,6 +813,36 @@
             "severity": "error",
             "category": "classifications",
             "message": "Sectors must only be declared at activity level OR for all transactions."
+          }
+        },
+        {
+          "if": "recipient-country or recipient-region",
+          "then": "not(transaction/recipient-country or transaction/recipient-region)",
+          "ruleInfo": {
+            "id": "3.6.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "Recipient countries or regions must only be declared at activity level OR for all transactions."
+          }
+        },
+        {
+          "if": "not(recipient-country or recipient-region)",
+          "then": "transaction[recipient-country or recipient-region]",
+          "ruleInfo": {
+            "id": "3.7.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
+          }
+        },
+        {
+          "if": "not(recipient-country or recipient-region)",
+          "then": "not(transaction[not(recipient-country or recipient-region)])",
+          "ruleInfo": {
+            "id": "3.7.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -465,9 +465,30 @@
         {
           "foreach": "recipient-region/@vocabulary",
           "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(recipient-region[@vocabulary = '$1']) = 1 and not(recipient-country)",
+                  "then": "not(recipient-region[@vocabulary = '$1']/@percentage) or recipient-region[@vocabulary = '$1']/@percentage = 100",
+                  "ruleInfo": {
+                    "id": "3.4.4",
+                    "severity": "error",
+                    "category": "geo",
+                    "message": "When a single recipient region in a vocabulary is declared, the percentage must either be omitted, or set to 100."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
+        },
+        {
+          "foreach": "recipient-region/@vocabulary",
+          "do": {
             "strict_sum": {
               "cases": [
                 {
+                  "condition": "count(recipient-region[@vocabulary = '$1']) > 1",
                   "paths": [
                     "recipient-region[@vocabulary = '$1']/@percentage",
                     "recipient-country/@percentage"
@@ -483,7 +504,7 @@
               ]
             }
           },
-          "subs": ["paths"]
+          "subs": ["paths", "condition"]
         },
         {
           "foreach": "country-budget-items/@vocabulary",
@@ -672,7 +693,7 @@
           }
         },
         {
-          "condition": "recipient-country and not(recipient-region)",
+          "condition": "count(recipient-country) > 1 and not(recipient-region)",
           "paths": ["recipient-country/@percentage"],
           "sum": 100,
           "ruleInfo": {
@@ -866,13 +887,23 @@
           }
         },
         {
-          "if": "count(recipient-country) > 0",
+          "if": "count(recipient-country) > 1",
           "then": "count(recipient-country) = count(recipient-country/@percentage)",
           "ruleInfo": {
             "id": "3.4.1",
             "severity": "error",
             "category": "geo",
             "message": "When multiple recipient countries or regions are declared, each must have a percentage."
+          }
+        },
+        {
+          "if": "count(recipient-country) = 1 and not(recipient-region)",
+          "then": "not(recipient-country/@percentage) or recipient-country/@percentage = 100",
+          "ruleInfo": {
+            "id": "3.1.4",
+            "severity": "error",
+            "category": "geo",
+            "message": "When a single recipient country is declared, the percentage must either be omitted, or set to 100."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -267,6 +267,7 @@
                 {
                   "if": "description[@type = '$1']/narrative",
                   "then": "string(description[@type = '$1']//narrative) != ''",
+                  "paths": ["description[@type = '$1']/narrative"],
                   "ruleInfo": {
                     "id": "4.4.1",
                     "severity": "error",
@@ -277,7 +278,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
@@ -307,6 +308,7 @@
                 {
                   "if": "count(recipient-region[@vocabulary = '$1']) > 1",
                   "then": "count(recipient-region[@vocabulary = '$1']) = count(recipient-region[@vocabulary = '$1']/@percentage)",
+                  "paths": ["recipient-region[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "3.4.1",
                     "severity": "error",
@@ -317,7 +319,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "recipient-region/@vocabulary",
@@ -327,6 +329,10 @@
                 {
                   "if": "count(recipient-region[@vocabulary = '$1']) = 1 and not(recipient-country)",
                   "then": "not(recipient-region[@vocabulary = '$1']/@percentage) or recipient-region[@vocabulary = '$1']/@percentage = 100",
+                  "paths": [
+                    "recipient-region[@vocabulary = '$1']",
+                    "recipient-country"
+                  ],
                   "ruleInfo": {
                     "id": "3.4.4",
                     "severity": "error",
@@ -337,7 +343,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "recipient-region/@vocabulary",
@@ -416,6 +422,9 @@
                 {
                   "if": "count(country-budget-items[@vocabulary = '$1']/budget-item) = 1",
                   "then": "not(country-budget-items[@vocabulary = '$1']/budget-item/@percentage) or country-budget-items[@vocabulary = '$1']/budget-item/@percentage = 100",
+                  "paths": [
+                    "country-budget-items[@vocabulary = '$1']/budget-item"
+                  ],
                   "ruleInfo": {
                     "id": "7.9.4",
                     "severity": "warning",
@@ -426,7 +435,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "default-aid-type[@vocabulary != 1]/@vocabulary",
@@ -476,6 +485,7 @@
                   "then": [
                     "count(sector[@vocabulary = '$1']) = count(sector[@vocabulary = '$1']/@percentage)"
                   ],
+                  "paths": ["sector[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "2.1.1",
                     "severity": "error",
@@ -486,7 +496,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
@@ -496,6 +506,7 @@
                 {
                   "if": "count(sector[@vocabulary = '$1']) = 1",
                   "then": "not(sector[@vocabulary = '$1']/@percentage) or sector[@vocabulary = '$1']/@percentage = 100",
+                  "paths": ["sector[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "2.1.4",
                     "severity": "",
@@ -506,7 +517,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         }
       ]
     },
@@ -628,6 +639,7 @@
         {
           "if": "title/narrative",
           "then": "string(title//narrative) != ''",
+          "paths": ["title/narrative"],
           "ruleInfo": {
             "id": "4.3.1",
             "severity": "error",
@@ -638,6 +650,7 @@
         {
           "if": "count(description[not(@type) or @type = '']/narrative) > 0",
           "then": "string(description[not(@type) or @type = '']//narrative) != ''",
+          "paths": ["description[not(@type) or @type = '']/narrative"],
           "ruleInfo": {
             "id": "4.4.1",
             "severity": "error",
@@ -648,6 +661,10 @@
         {
           "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
           "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])",
+          "paths": [
+            "sector[@vocabulary=98 or @vocabulary=99]",
+            "sector[@vocabulary=98 or @vocabulary=99]/narrative"
+          ],
           "ruleInfo": {
             "id": "2.2.1",
             "severity": "error",
@@ -658,6 +675,11 @@
         {
           "if": "count(sector[not(@vocabulary='')]) + count(sector[not(@vocabulary='1')]) > 0",
           "then": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 0",
+          "paths": [
+            "sector[not(@vocabulary='')]",
+            "sector[not(@vocabulary='1')]",
+            "sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "102.1.1",
             "severity": "warning",
@@ -668,6 +690,9 @@
         {
           "if": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 1",
           "then": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) = count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage)",
+          "paths": [
+            "sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "2.1.1",
             "severity": "error",
@@ -678,6 +703,9 @@
         {
           "if": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) = 1",
           "then": "not(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage) or sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage = 100",
+          "paths": [
+            "sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "2.1.4",
             "severity": "error",
@@ -688,6 +716,11 @@
         {
           "if": "count(default-aid-type[not(@vocabulary='')]) + count(default-aid-type[not(@vocabulary='1')]) > 0",
           "then": "count(default-aid-type[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 0",
+          "paths": [
+            "default-aid-type[not(@vocabulary='')]",
+            "default-aid-type[not(@vocabulary='1')]",
+            "default-aid-type[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "107.1.1",
             "severity": "warning",
@@ -698,6 +731,11 @@
         {
           "if": "count(transaction/aid-type[not(@vocabulary='')]) + count(transaction/aid-type[not(@vocabulary='1')]) > 0",
           "then": "count(transaction/aid-type[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 0",
+          "paths": [
+            "transaction/aid-type[not(@vocabulary='')]",
+            "transaction/aid-type[not(@vocabulary='1')]",
+            "transaction/aid-type[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "107.2.1",
             "severity": "warning",
@@ -708,6 +746,7 @@
         {
           "if": "count(sector) > 0",
           "then": "count(transaction/sector) < 1",
+          "paths": ["sector", "transaction/sector"],
           "ruleInfo": {
             "id": "6.6.2",
             "severity": "error",
@@ -718,6 +757,12 @@
         {
           "if": "recipient-country or recipient-region",
           "then": "not(transaction/recipient-country or transaction/recipient-region)",
+          "paths": [
+            "recipient-country",
+            "recipient-region",
+            "transaction/recipient-country",
+            "transaction/recipient-region"
+          ],
           "ruleInfo": {
             "id": "3.6.2",
             "severity": "error",
@@ -728,6 +773,11 @@
         {
           "if": "not(recipient-country or recipient-region)",
           "then": "transaction[recipient-country or recipient-region]",
+          "paths": [
+            "recipient-country",
+            "recipient-region",
+            "transaction[recipient-country or recipient-region]"
+          ],
           "ruleInfo": {
             "id": "3.7.1",
             "severity": "error",
@@ -738,6 +788,11 @@
         {
           "if": "not(recipient-country or recipient-region)",
           "then": "not(transaction[not(recipient-country or recipient-region)])",
+          "paths": [
+            "recipient-country",
+            "recipient-region",
+            "transaction[not(recipient-country or recipient-region)]"
+          ],
           "ruleInfo": {
             "id": "3.7.2",
             "severity": "error",
@@ -748,6 +803,7 @@
         {
           "if": "count(recipient-country) > 1 and not(recipient-region)",
           "then": "count(recipient-country) = count(recipient-country/@percentage)",
+          "paths": ["recipient-country", "recipient-region"],
           "ruleInfo": {
             "id": "3.1.1",
             "severity": "error",
@@ -758,6 +814,7 @@
         {
           "if": "count(recipient-country) = 1 and not(recipient-region)",
           "then": "not(recipient-country/@percentage) or recipient-country/@percentage = 100",
+          "paths": ["recipient-country", "recipient-region"],
           "ruleInfo": {
             "id": "3.1.4",
             "severity": "error",
@@ -1380,6 +1437,7 @@
         {
           "if": "@value",
           "then": "number(@value) = @value",
+          "paths": ["@value"],
           "ruleInfo": {
             "id": "8.8.2",
             "severity": "warning",
@@ -1396,6 +1454,7 @@
         {
           "if": "@value",
           "then": "not(@value)",
+          "paths": ["@value"],
           "ruleInfo": {
             "id": "8.8.3",
             "severity": "warning",
@@ -1425,6 +1484,7 @@
         {
           "if": "@value",
           "then": "number(@value) = @value",
+          "paths": ["@value"],
           "ruleInfo": {
             "id": "8.9.2",
             "severity": "warning",
@@ -1441,6 +1501,7 @@
         {
           "if": "@value",
           "then": "not(@value)",
+          "paths": ["@value"],
           "ruleInfo": {
             "id": "8.9.3",
             "severity": "warning",
@@ -1470,6 +1531,7 @@
         {
           "if": "@value",
           "then": "number(@value) = @value",
+          "paths": ["@value"],
           "ruleInfo": {
             "id": "8.10.2",
             "severity": "warning",
@@ -1486,6 +1548,7 @@
         {
           "if": "@value",
           "then": "not(@value)",
+          "paths": ["@value"],
           "ruleInfo": {
             "id": "8.10.3",
             "severity": "warning",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -135,7 +135,13 @@
               "cases": [
                 {
                   "paths": ["sector[@vocabulary = '$1']/@percentage"],
-                  "sum": 100
+                  "sum": 100,
+                  "ruleInfo": {
+                    "id": "2.1.2",
+                    "severity": "error",
+                    "category": "classifications",
+                    "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%."
+                  }
                 }
               ]
             }
@@ -167,7 +173,13 @@
           "paths": [
             "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage"
           ],
-          "sum": 100
+          "sum": 100,
+          "ruleInfo": {
+            "id": "2.1.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%."
+          }
         },
         {
           "condition": "not(recipient-region)",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -520,6 +520,38 @@
             }
           },
           "subs": ["if", "then"]
+        },
+        {
+          "foreach": "default-aid-type[@vocabulary != 1]/@vocabulary",
+          "do": {
+            "no_more_than_one": {
+              "cases": [
+                {
+                  "paths": ["default-aid-type[@vocabulary = '$1']"],
+                  "ruleInfo": {
+                    "id": "107.1.2",
+                    "severity": "warning",
+                    "category": "financial",
+                    "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["paths"]
+        }
+      ]
+    },
+    "no_more_than_one": {
+      "cases": [
+        {
+          "paths": ["default-aid-type[@vocabulary = '1' or not(@vocabulary)]"],
+          "ruleInfo": {
+            "id": "107.1.2",
+            "severity": "warning",
+            "category": "financial",
+            "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+          }
         }
       ]
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -455,6 +455,71 @@
             }
           },
           "subs": ["paths"]
+        },
+        {
+          "foreach": "country-budget-items/@vocabulary",
+          "do": {
+            "strict_sum": {
+              "cases": [
+                {
+                  "condition": "count(country-budget-items[@vocabulary = '$1']/budget-item) > 1",
+                  "paths": [
+                    "country-budget-items[@vocabulary = '$1']/budget-item/@percentage"
+                  ],
+                  "sum": 100,
+                  "ruleInfo": {
+                    "id": "7.9.2",
+                    "severity": "warning",
+                    "category": "financial",
+                    "message": "Percentage values for budget items, should add up to 100%."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["paths", "condition"]
+        },
+        {
+          "foreach": "country-budget-items/@vocabulary",
+          "do": {
+            "atleast_one": {
+              "cases": [
+                {
+                  "condition": "count(country-budget-items[@vocabulary = '$1']/budget-item) > 1",
+                  "paths": [
+                    "country-budget-items[@vocabulary = '$1']/budget-item/@percentage"
+                  ],
+                  "ruleInfo": {
+                    "id": "7.9.1",
+                    "severity": "warning",
+                    "category": "financial",
+                    "message": "When multiple budget items are declared, each must have a percentage."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["paths", "condition"]
+        },
+        {
+          "foreach": "country-budget-items/@vocabulary",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(country-budget-items[@vocabulary = '$1']/budget-item) = 1",
+                  "then": "not(country-budget-items[@vocabulary = '$1']/budget-item/@percentage) or country-budget-items[@vocabulary = '$1']/budget-item/@percentage = 100",
+                  "ruleInfo": {
+                    "id": "7.9.4",
+                    "severity": "warning",
+                    "category": "financial",
+                    "message": "When a single budget item is declared, the percentage must either be omitted, or set to 100."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
         }
       ]
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -8,7 +8,10 @@
             "id": "1.1.3",
             "severity": "error",
             "category": "identifiers",
-            "message": "The activity identifier must be different to the organisation identifier of the reporting organisation."
+            "message": "The activity identifier must be different to the organisation identifier of the reporting organisation.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/iati-identifier/"
+            }
           }
         }
       ]
@@ -23,7 +26,10 @@
             "id": "1.1.21",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The activity identifier should begin with your IATI organisation identifier (either the current IATI Organisation identifier for the reporting organisation or a previous version included in other-identifier element) followed by a unique string for the activity separated by a hyphen"
+            "message": "The activity identifier should begin with your IATI organisation identifier (either the current IATI Organisation identifier for the reporting organisation or a previous version included in other-identifier element) followed by a unique string for the activity separated by a hyphen",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/iati-identifier/"
+            }
           }
         },
         {
@@ -34,7 +40,10 @@
             "id": "1.14.8",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting organisation id must start with an approved agency code."
+            "message": "The reporting organisation id must start with an approved agency code.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -47,7 +56,10 @@
             "id": "6.11.1",
             "severity": "error",
             "category": "information",
-            "message": "The activity must have a planned start date or an actual start date."
+            "message": "The activity must have a planned start date or an actual start date.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -56,7 +68,10 @@
             "id": "6.2.2",
             "severity": "error",
             "category": "classifications",
-            "message": "Each activity must have a specified sector, either at activity level OR for all transactions."
+            "message": "Each activity must have a specified sector, either at activity level OR for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         }
       ]
@@ -70,7 +85,8 @@
             "id": "4.1.1",
             "severity": "error",
             "category": "information",
-            "message": "The activity should specify a default language OR the language must be specified for each narrative element."
+            "message": "The activity should specify a default language OR the language must be specified for each narrative element.",
+            "link": { "path": "codelists/Language/" }
           }
         },
         {
@@ -80,7 +96,10 @@
             "id": "6.7.2",
             "severity": "error",
             "category": "classifications",
-            "message": "If sector is declared at transaction level, a sector must be declared for all transactions."
+            "message": "If sector is declared at transaction level, a sector must be declared for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -90,7 +109,8 @@
             "id": "7.8.1",
             "severity": "error",
             "category": "financial",
-            "message": "The activity should specify a default currency OR the currency must be specified for each monetary value."
+            "message": "The activity should specify a default currency OR the currency must be specified for each monetary value.",
+            "link": { "path": "codelists/Currency/" }
           }
         }
       ]
@@ -103,7 +123,10 @@
             "id": "11.1.1",
             "severity": "error",
             "category": "information",
-            "message": "The last updated datetime of the activity must not be in the future."
+            "message": "The last updated datetime of the activity must not be in the future.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/"
+            }
           }
         }
       ]
@@ -117,7 +140,10 @@
             "id": "11.1.2",
             "severity": "error",
             "category": "iati",
-            "message": "The planned start date of the activity must be before the planned end date."
+            "message": "The planned start date of the activity must be before the planned end date.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -127,7 +153,10 @@
             "id": "11.1.3",
             "severity": "error",
             "category": "iati",
-            "message": "The actual start date of the activity must be before the actual end date."
+            "message": "The actual start date of the activity must be before the actual end date.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -137,7 +166,10 @@
             "id": "11.1.4",
             "severity": "error",
             "category": "iati",
-            "message": "The actual start date of the activity must not be in the future."
+            "message": "The actual start date of the activity must not be in the future.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -147,7 +179,10 @@
             "id": "11.1.5",
             "severity": "error",
             "category": "iati",
-            "message": "The actual end date of the activity must not be in the future."
+            "message": "The actual end date of the activity must not be in the future.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -157,7 +192,10 @@
             "id": "11.2.1",
             "severity": "error",
             "category": "financial",
-            "message": "The transaction date must not be in the future."
+            "message": "The transaction date must not be in the future.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/financial-transactions/"
+            }
           }
         },
         {
@@ -167,7 +205,10 @@
             "id": "11.2.2",
             "severity": "error",
             "category": "financial",
-            "message": "The transaction value date must not be in the future."
+            "message": "The transaction value date must not be in the future.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/financial-transactions/"
+            }
           }
         }
       ]
@@ -193,7 +234,10 @@
             "id": "1.14.13",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?."
+            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -215,7 +259,10 @@
             "id": "1.14.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org identifier should not start or end with spaces or newlines."
+            "message": "The reporting-org identifier should not start or end with spaces or newlines.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         },
         {
@@ -262,7 +309,10 @@
                     "id": "4.4.1",
                     "severity": "error",
                     "category": "information",
-                    "message": "The description must contain narrative content."
+                    "message": "The description must contain narrative content.",
+                    "link": {
+                      "path": "activity-standard/iati-activities/iati-activity/title/"
+                    }
                   }
                 }
               ]
@@ -282,7 +332,10 @@
                     "id": "2.1.2",
                     "severity": "error",
                     "category": "classifications",
-                    "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%."
+                    "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+                    }
                   }
                 }
               ]
@@ -303,7 +356,10 @@
                     "id": "3.4.1",
                     "severity": "error",
                     "category": "geo",
-                    "message": "When multiple recipient countries or regions are declared, each must have a percentage."
+                    "message": "When multiple recipient countries or regions are declared, each must have a percentage.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+                    }
                   }
                 }
               ]
@@ -327,7 +383,10 @@
                     "id": "3.4.4",
                     "severity": "error",
                     "category": "geo",
-                    "message": "When a single recipient region in a vocabulary is declared, the percentage must either be omitted, or set to 100."
+                    "message": "When a single recipient region in a vocabulary is declared, the percentage must either be omitted, or set to 100.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+                    }
                   }
                 }
               ]
@@ -351,7 +410,10 @@
                     "id": "3.4.2",
                     "severity": "error",
                     "category": "geo",
-                    "message": "Percentage values for recipient countries or regions, must add up to 100%."
+                    "message": "Percentage values for recipient countries or regions, must add up to 100%.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+                    }
                   }
                 }
               ]
@@ -374,7 +436,10 @@
                     "id": "7.9.2",
                     "severity": "warning",
                     "category": "financial",
-                    "message": "Percentage values for budget items, should add up to 100%."
+                    "message": "Percentage values for budget items, should add up to 100%.",
+                    "link": {
+                      "path": "activity-standard/iati-activities/iati-activity/country-budget-items/budget-item/"
+                    }
                   }
                 }
               ]
@@ -396,7 +461,10 @@
                     "id": "7.9.1",
                     "severity": "warning",
                     "category": "financial",
-                    "message": "When multiple budget items are declared, each must have a percentage."
+                    "message": "When multiple budget items are declared, each must have a percentage.",
+                    "link": {
+                      "path": "activity-standard/iati-activities/iati-activity/country-budget-items/budget-item/"
+                    }
                   }
                 }
               ]
@@ -419,7 +487,10 @@
                     "id": "7.9.4",
                     "severity": "warning",
                     "category": "financial",
-                    "message": "When a single budget item is declared, the percentage must either be omitted, or set to 100."
+                    "message": "When a single budget item is declared, the percentage must either be omitted, or set to 100.",
+                    "link": {
+                      "path": "activity-standard/iati-activities/iati-activity/country-budget-items/budget-item/"
+                    }
                   }
                 }
               ]
@@ -459,7 +530,10 @@
                     "id": "2.1.1",
                     "severity": "error",
                     "category": "classifications",
-                    "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
+                    "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+                    }
                   }
                 }
               ]
@@ -480,7 +554,10 @@
                     "id": "2.1.4",
                     "severity": "error",
                     "category": "classifications",
-                    "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
+                    "message": "When a single sector is declared, the percentage must either be omitted, or set to 100.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+                    }
                   }
                 }
               ]
@@ -517,7 +594,10 @@
             "id": "2.1.2",
             "severity": "error",
             "category": "classifications",
-            "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%."
+            "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -528,7 +608,10 @@
             "id": "3.1.2",
             "severity": "error",
             "category": "geo",
-            "message": "Percentage values for recipient countries, must add up to 100%."
+            "message": "Percentage values for recipient countries, must add up to 100%.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         }
       ]
@@ -543,7 +626,10 @@
             "id": "12.1.1",
             "severity": "error",
             "category": "geo",
-            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive).",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
@@ -554,7 +640,10 @@
             "id": "12.1.1",
             "severity": "error",
             "category": "geo",
-            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive).",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
@@ -565,7 +654,10 @@
             "id": "12.3.1",
             "severity": "error",
             "category": "classifications",
-            "message": "The sector percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The sector percentage value must be between 0.0 and 100.0 (inclusive).",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -576,7 +668,10 @@
             "id": "12.2.1",
             "severity": "error",
             "category": "financial",
-            "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The percentage value must be between 0.0 and 100.0 (inclusive).",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/capital-spend/"
+            }
           }
         },
         {
@@ -587,7 +682,10 @@
             "id": "12.2.1",
             "severity": "error",
             "category": "financial",
-            "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The percentage value must be between 0.0 and 100.0 (inclusive).",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/capital-spend/"
+            }
           }
         }
       ]
@@ -602,7 +700,10 @@
             "id": "4.3.1",
             "severity": "error",
             "category": "information",
-            "message": "The title must contain narrative content."
+            "message": "The title must contain narrative content.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/title/"
+            }
           }
         },
         {
@@ -613,7 +714,10 @@
             "id": "4.4.1",
             "severity": "error",
             "category": "information",
-            "message": "The description must contain narrative content."
+            "message": "The description must contain narrative content.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/title/"
+            }
           }
         },
         {
@@ -627,7 +731,10 @@
             "id": "2.2.1",
             "severity": "error",
             "category": "classifications",
-            "message": "When using a reporting organisation sector code (vocabulary 98 or 99), it must include a narrative."
+            "message": "When using a reporting organisation sector code (vocabulary 98 or 99), it must include a narrative.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -642,7 +749,10 @@
             "id": "102.1.1",
             "severity": "warning",
             "category": "information",
-            "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used."
+            "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -655,7 +765,10 @@
             "id": "2.1.1",
             "severity": "error",
             "category": "classifications",
-            "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
+            "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -668,7 +781,10 @@
             "id": "2.1.4",
             "severity": "error",
             "category": "classifications",
-            "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
+            "message": "When a single sector is declared, the percentage must either be omitted, or set to 100.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -709,7 +825,10 @@
             "id": "6.6.2",
             "severity": "error",
             "category": "classifications",
-            "message": "Sectors must only be declared at activity level OR for all transactions."
+            "message": "Sectors must only be declared at activity level OR for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -725,7 +844,10 @@
             "id": "3.6.2",
             "severity": "error",
             "category": "financial",
-            "message": "Recipient countries or regions must only be declared at activity level OR for all transactions."
+            "message": "Recipient countries or regions must only be declared at activity level OR for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/financial-transactions/"
+            }
           }
         },
         {
@@ -740,7 +862,10 @@
             "id": "3.7.1",
             "severity": "error",
             "category": "financial",
-            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
+            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
@@ -755,7 +880,10 @@
             "id": "3.7.2",
             "severity": "error",
             "category": "financial",
-            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
+            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
@@ -766,7 +894,10 @@
             "id": "3.1.1",
             "severity": "error",
             "category": "geo",
-            "message": "When multiple recipient countries are declared, each must have a percentage."
+            "message": "When multiple recipient countries are declared, each must have a percentage.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
@@ -777,7 +908,10 @@
             "id": "3.1.4",
             "severity": "error",
             "category": "geo",
-            "message": "When a single recipient country is declared, the percentage must either be omitted, or set to 100."
+            "message": "When a single recipient country is declared, the percentage must either be omitted, or set to 100.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         }
       ]
@@ -980,7 +1114,10 @@
             "id": "6.14.1",
             "severity": "error",
             "category": "classifications",
-            "message": "When using a policy marker code for vocabulary 1, it must include a significance."
+            "message": "When using a policy marker code for vocabulary 1, it must include a significance.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+            }
           }
         },
         {
@@ -990,7 +1127,10 @@
             "id": "6.13.1",
             "severity": "error",
             "category": "classifications",
-            "message": "When using a reporting organisation policy marker code (vocabulary 99), it must include a narrative."
+            "message": "When using a reporting organisation policy marker code (vocabulary 99), it must include a narrative.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+            }
           }
         }
       ]
@@ -1007,7 +1147,10 @@
             "id": "1.18.8",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting organisation id must start with an approved agency code."
+            "message": "The reporting organisation id must start with an approved agency code.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -1022,7 +1165,10 @@
             "id": "1.12.13",
             "severity": "warning",
             "category": "organisation",
-            "message": "The organisation-identifier must not contain any of the symbols /, &, | or ?."
+            "message": "The organisation-identifier must not contain any of the symbols /, &, | or ?.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         },
         {
@@ -1033,7 +1179,10 @@
             "id": "1.18.13",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?."
+            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -1046,7 +1195,10 @@
             "id": "1.12.1",
             "severity": "warning",
             "category": "organisation",
-            "message": "The organisation-identifier should not start or end with spaces or newlines."
+            "message": "The organisation-identifier should not start or end with spaces or newlines.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         },
         {
@@ -1064,7 +1216,10 @@
             "id": "1.18.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org identifier should not start or end with spaces or newlines."
+            "message": "The reporting-org identifier should not start or end with spaces or newlines.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -1091,7 +1246,8 @@
             "id": "4.5.1",
             "severity": "error",
             "category": "information",
-            "message": "The organisation should specify a default language, or the language should be specified for each narrative element."
+            "message": "The organisation should specify a default language, or the language should be specified for each narrative element.",
+            "link": { "path": "codelists/Language/" }
           }
         },
         {
@@ -1101,7 +1257,8 @@
             "id": "7.8.2",
             "severity": "error",
             "category": "financial",
-            "message": "The financial value must have a specified currency, or the organisation must declare a default currency."
+            "message": "The financial value must have a specified currency, or the organisation must declare a default currency.",
+            "link": { "path": "codelists/Currency/" }
           }
         }
       ]
@@ -1116,7 +1273,10 @@
             "id": "6.10.1",
             "severity": "error",
             "category": "participating",
-            "message": "The participating organisation must have an identifier or a narrative."
+            "message": "The participating organisation must have an identifier or a narrative.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-participants/"
+            }
           }
         }
       ]
@@ -1169,7 +1329,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1185,7 +1348,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1199,7 +1365,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1215,7 +1384,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1229,7 +1401,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1245,7 +1420,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1260,7 +1438,10 @@
             "id": "11.3.1",
             "severity": "error",
             "category": "financial",
-            "message": "The budget line value date must be within the budget period."
+            "message": "The budget line value date must be within the budget period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1274,7 +1455,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1290,7 +1474,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1304,7 +1491,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1320,7 +1510,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1334,7 +1527,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1349,7 +1545,10 @@
             "id": "8.11.1",
             "severity": "error",
             "category": "performance",
-            "message": "A reference code must only be declared at result OR result indicator level."
+            "message": "A reference code must only be declared at result OR result indicator level.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/reference/"
+            }
           }
         }
       ]
@@ -1365,7 +1564,10 @@
             "id": "8.6.1",
             "severity": "error",
             "category": "performance",
-            "message": "The start date of the indicator period must be before the end date of the indicator period."
+            "message": "The start date of the indicator period must be before the end date of the indicator period.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/period-start/"
+            }
           }
         }
       ]
@@ -1381,7 +1583,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1395,7 +1600,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1410,7 +1618,10 @@
             "id": "8.8.1",
             "severity": "error",
             "category": "performance",
-            "message": "The baseline must have a value when the indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+            "message": "The baseline must have a value when the indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal).",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/baseline/"
+            }
           }
         }
       ]
@@ -1425,7 +1636,10 @@
             "id": "8.8.2",
             "severity": "warning",
             "category": "performance",
-            "message": "The baseline value should be a valid number for all non-qualitative measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+            "message": "The baseline value should be a valid number for all non-qualitative measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal).",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/baseline/"
+            }
           }
         }
       ]
@@ -1442,7 +1656,10 @@
             "id": "8.8.3",
             "severity": "warning",
             "category": "performance",
-            "message": "The baseline value should be omitted for qualitative measures."
+            "message": "The baseline value should be omitted for qualitative measures.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/baseline/"
+            }
           }
         }
       ]
@@ -1457,7 +1674,10 @@
             "id": "8.9.1",
             "severity": "error",
             "category": "performance",
-            "message": "The target must have a value when indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+            "message": "The target must have a value when indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal).",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/target/"
+            }
           }
         }
       ]
@@ -1472,7 +1692,10 @@
             "id": "8.9.2",
             "severity": "warning",
             "category": "performance",
-            "message": "The target value should be a valid number for all non-qualitative measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+            "message": "The target value should be a valid number for all non-qualitative measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal).",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/target/"
+            }
           }
         }
       ]
@@ -1489,7 +1712,10 @@
             "id": "8.9.3",
             "severity": "warning",
             "category": "performance",
-            "message": "The target value should be omitted for qualitative measures."
+            "message": "The target value should be omitted for qualitative measures.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/target/"
+            }
           }
         }
       ]
@@ -1504,7 +1730,10 @@
             "id": "8.10.1",
             "severity": "error",
             "category": "performance",
-            "message": "The actual must have a value when the indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+            "message": "The actual must have a value when the indicator measure is non-qualitative (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal).",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/actual/"
+            }
           }
         }
       ]
@@ -1519,7 +1748,10 @@
             "id": "8.10.2",
             "severity": "warning",
             "category": "performance",
-            "message": "The actual value should be a valid number for all non-qualitative indicator measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal)."
+            "message": "The actual value should be a valid number for all non-qualitative indicator measures (e.g. 1 = unit, 2 = percentage, 3 = nominal, 4 = ordinal).",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/actual/"
+            }
           }
         }
       ]
@@ -1536,7 +1768,10 @@
             "id": "8.10.3",
             "severity": "warning",
             "category": "performance",
-            "message": "The actual value should be omitted for qualitative indicator measures."
+            "message": "The actual value should be omitted for qualitative indicator measures.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/actual/"
+            }
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -13,7 +13,7 @@
         }
       ]
     },
-    "startsWith": {
+    "startswith": {
       "cases": [
         {
           "prefix": ["reporting-org/@ref", "other-identifier[@type='B1']/@ref"],
@@ -34,6 +34,132 @@
             "severity": "warning",
             "category": "identifiers",
             "message": "The activity identifier should be your IATI Organisation Identifier followed by a unique string for the activity separated by a hyphen e.g. COH-1234-activity1"
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.3.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The iati-identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["planned-disbursement/provider-org/@ref"],
+          "ruleInfo": {
+            "id": "1.10.8",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["other-identifier/owner-org/@ref"],
+          "ruleInfo": {
+            "id": "1.11.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The owner organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.14.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["planned-disbursement/receiver-org/@ref"],
+          "ruleInfo": {
+            "id": "1.15.8",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiving organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["other-identifier[@type='B1']/@ref"],
+          "ruleInfo": {
+            "id": "1.16.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous reporting organisation identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["other-identifier[@type='A3']/@ref"],
+          "ruleInfo": {
+            "id": "1.6.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous activity identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": [
+            "planned-disbursement/provider-org/@provider-activity-id",
+            "transaction/provider-org/@provider-activity-id"
+          ],
+          "ruleInfo": {
+            "id": "1.4.8",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider activity identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": [
+            "planned-disbursement/receiver-org/@receiver-activity-id",
+            "/transaction/receiver-org/@receiver-activity-id"
+          ],
+          "ruleInfo": {
+            "id": "1.5.8",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver activity identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["related-activity/@ref"],
+          "ruleInfo": {
+            "id": "1.7.8",
+            "severity": "warning",
+            "category": "relations",
+            "message": "The related activity identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["participating-org/@ref"],
+          "ruleInfo": {
+            "id": "1.8.8",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating organisation identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["participating-org/@activity-id"],
+          "ruleInfo": {
+            "id": "1.9.8",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating organisation activity identifier must start with an approved agency code."
           }
         }
       ]
@@ -382,6 +508,40 @@
     }
   },
   "//iati-organisation": {
+    "startswith": {
+      "cases": [
+        {
+          "prefix": "ORG-ID",
+          "paths": ["organisation-identifier"],
+          "ruleInfo": {
+            "id": "1.12.8",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The organisation-identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["recipient-org-budget/recipient-org/@ref"],
+          "ruleInfo": {
+            "id": "1.17.8",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The recipient organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID",
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.18.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting organisation id must start with an approved agency code."
+          }
+        }
+      ]
+    },
     "regex_matches": {
       "cases": [
         {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -580,6 +580,26 @@
             }
           },
           "subs": ["if", "then"]
+        },
+        {
+          "foreach": "sector[@vocabulary != '1']/@vocabulary",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(sector[@vocabulary = '$1']) = 1",
+                  "then": "not(sector[@vocabulary = '$1']/@percentage) or sector[@vocabulary = '$1']/@percentage = 100",
+                  "ruleInfo": {
+                    "id": "2.1.4",
+                    "severity": "",
+                    "category": "classifications",
+                    "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
         }
       ]
     },
@@ -610,6 +630,7 @@
     "strict_sum": {
       "cases": [
         {
+          "condition": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage) > 1",
           "paths": [
             "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage"
           ],
@@ -723,6 +744,16 @@
             "severity": "error",
             "category": "classifications",
             "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
+          }
+        },
+        {
+          "if": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) = 1",
+          "then": "not(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage) or sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage = 100",
+          "ruleInfo": {
+            "id": "2.1.4",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
           }
         },
         {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -278,11 +278,23 @@
       "cases": [
         {
           "condition": "@vocabulary='1' or not(@vocabulary)",
-          "paths": ["@significance"]
+          "paths": ["@significance"],
+          "ruleInfo": {
+            "id": "6.14.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When using a policy marker code for vocabulary 1, it must include a significance."
+          }
         },
         {
           "condition": "@vocabulary='99'",
-          "paths": ["narrative"]
+          "paths": ["narrative"],
+          "ruleInfo": {
+            "id": "6.13.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When using a reporting organisation policy marker code (vocabulary 99), it must include a narrative."
+          }
         }
       ]
     }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -38,128 +38,12 @@
         },
         {
           "prefix": "ORG-ID-PREFIX",
-          "paths": ["iati-identifier"],
-          "ruleInfo": {
-            "id": "1.3.8",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The iati-identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["planned-disbursement/provider-org/@ref"],
-          "ruleInfo": {
-            "id": "1.10.8",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The provider organisation id must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["other-identifier/owner-org/@ref"],
-          "ruleInfo": {
-            "id": "1.11.8",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The owner organisation id must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.14.8",
             "severity": "warning",
             "category": "identifiers",
             "message": "The reporting organisation id must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["planned-disbursement/receiver-org/@ref"],
-          "ruleInfo": {
-            "id": "1.15.8",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The receiving organisation id must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["other-identifier[@type='B1']/@ref"],
-          "ruleInfo": {
-            "id": "1.16.8",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The previous reporting organisation identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["other-identifier[@type='A3']/@ref"],
-          "ruleInfo": {
-            "id": "1.6.8",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The previous activity identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": [
-            "planned-disbursement/provider-org/@provider-activity-id",
-            "transaction/provider-org/@provider-activity-id"
-          ],
-          "ruleInfo": {
-            "id": "1.4.8",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The provider activity identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": [
-            "planned-disbursement/receiver-org/@receiver-activity-id",
-            "/transaction/receiver-org/@receiver-activity-id"
-          ],
-          "ruleInfo": {
-            "id": "1.5.8",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The receiver activity identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["related-activity/@ref"],
-          "ruleInfo": {
-            "id": "1.7.8",
-            "severity": "warning",
-            "category": "relations",
-            "message": "The related activity identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["participating-org/@ref"],
-          "ruleInfo": {
-            "id": "1.8.8",
-            "severity": "warning",
-            "category": "participating",
-            "message": "The participating organisation identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["participating-org/@activity-id"],
-          "ruleInfo": {
-            "id": "1.9.8",
-            "severity": "warning",
-            "category": "participating",
-            "message": "The participating organisation activity identifier must start with an approved agency code."
           }
         }
       ]
@@ -317,36 +201,6 @@
             "severity": "warning",
             "category": "identifiers",
             "message": "The reporting-org idenitifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["other-identifier[@type='B1']/@ref"],
-          "ruleInfo": {
-            "id": "1.16.13",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The previous reporting organisation identifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["other-identifier[@type='A3']/@ref"],
-          "ruleInfo": {
-            "id": "1.6.13",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The previous activity identifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["related-activity/@ref"],
-          "ruleInfo": {
-            "id": "1.7.13",
-            "severity": "warning",
-            "category": "relations",
-            "message": "The related activity identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -978,16 +832,6 @@
             "category": "financial",
             "message": "The provider organisation idenitifier must not contain any of the symbols /, &, | or ?."
           }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["@provider-activity-id"],
-          "ruleInfo": {
-            "id": "1.4.13",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The provider-org activity idenitifier must not contain any of the symbols /, &, | or ?."
-          }
         }
       ]
     },
@@ -1061,16 +905,6 @@
             "category": "financial",
             "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
           }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["@receiver-activity-id"],
-          "ruleInfo": {
-            "id": "1.5.13",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The receiver-org activity idenitifier must not contain any of the symbols /, &, | or ?."
-          }
         }
       ]
     }
@@ -1106,26 +940,6 @@
       "cases": [
         {
           "prefix": "ORG-ID-PREFIX",
-          "paths": ["organisation-identifier"],
-          "ruleInfo": {
-            "id": "1.12.8",
-            "severity": "warning",
-            "category": "organisation",
-            "message": "The organisation-identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["recipient-org-budget/recipient-org/@ref"],
-          "ruleInfo": {
-            "id": "1.17.8",
-            "severity": "warning",
-            "category": "organisation",
-            "message": "The recipient organisation id must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.18.8",
@@ -1146,16 +960,6 @@
             "severity": "warning",
             "category": "organisation",
             "message": "The organisation-idenitifer must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["recipient-org-budget/recipient-org/@ref"],
-          "ruleInfo": {
-            "id": "1.17.13",
-            "severity": "warning",
-            "category": "organisation",
-            "message": "The recipient organisation identifier must not contain any of the symbols /, &, | or ?."
           }
         },
         {
@@ -1263,16 +1067,6 @@
             "severity": "warning",
             "category": "participating",
             "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["@activity-id"],
-          "ruleInfo": {
-            "id": "1.9.13",
-            "severity": "warning",
-            "category": "participating",
-            "message": "The participating-org activity identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -219,12 +219,24 @@
         {
           "paths": ["recipient-country/@percentage"],
           "min": 0.0,
-          "max": 100.0
+          "max": 100.0,
+          "ruleInfo": {
+            "id": "12.1.1",
+            "severity": "error",
+            "category": "geo",
+            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
         },
         {
           "paths": ["recipient-region/@percentage"],
           "min": 0.0,
-          "max": 100.0
+          "max": 100.0,
+          "ruleInfo": {
+            "id": "12.1.1",
+            "severity": "error",
+            "category": "geo",
+            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
         },
         {
           "paths": ["sector/@percentage"],

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -64,7 +64,16 @@
             "message": "The activity should specify a default language OR the language must be specified for each narrative element."
           }
         },
-        { "one": "sector", "all": "sector" },
+        {
+          "one": "sector",
+          "all": "sector",
+          "ruleInfo": {
+            "id": "6.7.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "If sector is declared at transaction level, a sector must be declared for all transactions."
+          }
+        },
         { "one": "@default-currency", "all": "currency" }
       ]
     },

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -887,13 +887,13 @@
           }
         },
         {
-          "if": "count(recipient-country) > 1",
+          "if": "count(recipient-country) > 1 and not(recipient-region)",
           "then": "count(recipient-country) = count(recipient-country/@percentage)",
           "ruleInfo": {
-            "id": "3.4.1",
+            "id": "3.1.1",
             "severity": "error",
             "category": "geo",
-            "message": "When multiple recipient countries or regions are declared, each must have a percentage."
+            "message": "When multiple recipient countries are declared, each must have a percentage."
           }
         },
         {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -539,6 +539,25 @@
             }
           },
           "subs": ["paths"]
+        },
+        {
+          "foreach": "transaction/aid-type[@vocabulary != 1]/@vocabulary",
+          "do": {
+            "no_more_than_one": {
+              "cases": [
+                {
+                  "paths": ["transaction/aid-type[@vocabulary = '$1']"],
+                  "ruleInfo": {
+                    "id": "107.2.2",
+                    "severity": "warning",
+                    "category": "financial",
+                    "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["paths"]
         }
       ]
     },
@@ -551,6 +570,17 @@
             "severity": "warning",
             "category": "financial",
             "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+          }
+        },
+        {
+          "paths": [
+            "transaction/aid-type[@vocabulary = '1' or not(@vocabulary)]"
+          ],
+          "ruleInfo": {
+            "id": "107.2.2",
+            "severity": "warning",
+            "category": "financial",
+            "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -184,7 +184,13 @@
                     "recipient-region[@vocabulary = '$1']/@percentage",
                     "recipient-country/@percentage"
                   ],
-                  "sum": 100
+                  "sum": 100,
+                  "ruleInfo": {
+                    "id": "3.4.2",
+                    "severity": "error",
+                    "category": "geo",
+                    "message": "Percentage values for recipient countries or regions, must add up to 100%."
+                  }
                 }
               ]
             }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -17,23 +17,13 @@
       "cases": [
         {
           "prefix": ["reporting-org/@ref", "other-identifier[@type='B1']/@ref"],
-          "paths": ["iati-identifier"],
-          "ruleInfo": {
-            "id": "1.1.1",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The activity identifier should begin with the organisation identifier of the reporting organisation (or a previous version included in the other-identifier element)."
-          }
-        },
-        {
-          "prefix": ["reporting-org/@ref", "other-identifier[@type='B1']/@ref"],
           "separator": "-",
           "paths": ["iati-identifier"],
           "ruleInfo": {
             "id": "1.1.21",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The activity identifier should be your IATI Organisation Identifier followed by a unique string for the activity separated by a hyphen e.g. COH-1234-activity1"
+            "message": "The activity identifier should begin with your IATI organisation identifier (either the current IATI Organisation identifier for the reporting organisation or a previous version included in other-identifier element) followed by a unique string for the activity separated by a hyphen"
           }
         },
         {
@@ -423,7 +413,7 @@
                   "if": "count(country-budget-items[@vocabulary = '$1']/budget-item) = 1",
                   "then": "not(country-budget-items[@vocabulary = '$1']/budget-item/@percentage) or country-budget-items[@vocabulary = '$1']/budget-item/@percentage = 100",
                   "paths": [
-                    "country-budget-items[@vocabulary = '$1']/budget-item"
+                    "country-budget-items[@vocabulary = '$1']/budget-item/@percentage"
                   ],
                   "ruleInfo": {
                     "id": "7.9.4",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -17,17 +17,7 @@
     "atleast_one": {
       "cases": [
         { "paths": ["activity-date[@type='1' or @type='2']"] },
-        { "paths": ["sector", "transaction/sector"] },
-        {
-          "if": "count(sector[not(@vocabulary='')]) + count(sector[not(@vocabulary='1')]) > 0",
-          "then": "count(sector[@vocabulary='']) + count(sector[@vocabulary='1']) + count(sector[not(@vocabulary)]) > 0",
-          "ruleInfo": {
-            "id": "102.1.1",
-            "severity": "warning",
-            "category": "information",
-            "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used."
-          }
-        }
+        { "paths": ["sector", "transaction/sector"] }
       ]
     },
     "one_or_all": {
@@ -201,6 +191,16 @@
             "severity": "error",
             "category": "classifications",
             "message": "When using a reporting organisation sector code (vocabulary 98 or 99), it must include a narrative."
+          }
+        },
+        {
+          "if": "count(sector[not(@vocabulary='')]) + count(sector[not(@vocabulary='1')]) > 0",
+          "then": "count(sector[@vocabulary='']) + count(sector[@vocabulary='1']) + count(sector[not(@vocabulary)]) > 0",
+          "ruleInfo": {
+            "id": "102.1.1",
+            "severity": "warning",
+            "category": "information",
+            "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -772,14 +772,62 @@
       "cases": [{ "paths": ["@value"] }]
     }
   },
+  "//result/indicator[@measure='5']/baseline": {
+    "if_then": {
+      "cases": [
+        {
+          "if": "@value",
+          "then": "not(@value)",
+          "ruleInfo": {
+            "id": "8.8.3",
+            "severity": "warning",
+            "category": "performance",
+            "message": "The baseline value should be omitted for qualitative measures."
+          }
+        }
+      ]
+    }
+  },
   "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/target": {
     "atleast_one": {
       "cases": [{ "paths": ["@value"] }]
     }
   },
+  "//result/indicator[@measure='5']/period/target": {
+    "if_then": {
+      "cases": [
+        {
+          "if": "@value",
+          "then": "not(@value)",
+          "ruleInfo": {
+            "id": "8.9.3",
+            "severity": "warning",
+            "category": "performance",
+            "message": "The target value should be omitted for qualitative measures."
+          }
+        }
+      ]
+    }
+  },
   "//result/indicator[@measure='1' or @measure='2' or @measure='3' or @measure='4']/period/actual": {
     "atleast_one": {
       "cases": [{ "paths": ["@value"] }]
+    }
+  },
+  "//result/indicator[@measure='5']/period/actual": {
+    "if_then": {
+      "cases": [
+        {
+          "if": "@value",
+          "then": "not(@value)",
+          "ruleInfo": {
+            "id": "8.10.3",
+            "severity": "warning",
+            "category": "performance",
+            "message": "The actual value should be omitted for qualitative indicator measures."
+          }
+        }
+      ]
     }
   }
 }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -267,14 +267,54 @@
     "regex_matches": {
       "cases": [
         {
-          "regex": "[^\\/\\&\\|\\?]+",
-          "paths": [
-            "reporting-org/@ref",
-            "iati-identifier",
-            "participating-org/@ref",
-            "transaction/provider-org/@ref",
-            "transaction/receiver-org/@ref"
-          ]
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.3.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The iati-identifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.14.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting-org idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["other-identifier[@type='B1']/@ref"],
+          "ruleInfo": {
+            "id": "1.16.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous reporting organisation identifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["other-identifier[@type='A3']/@ref"],
+          "ruleInfo": {
+            "id": "1.6.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous activity identifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["related-activity/@ref"],
+          "ruleInfo": {
+            "id": "1.7.13",
+            "severity": "warning",
+            "category": "relations",
+            "message": "The related activity identifier must not contain any of the symbols /, &, | or ?."
+          }
         }
       ]
     },
@@ -286,7 +326,7 @@
             "id": "1.3.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The iati-idenitifier should not start or end with spaces or newlines."
+            "message": "The iati-identifier should not start or end with spaces or newlines."
           }
         },
         {
@@ -526,8 +566,22 @@
           "ruleInfo": {
             "id": "1.11.1",
             "severity": "warning",
-            "category": "financial",
+            "category": "identifiers",
             "message": "The owner organisation idenitifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
+    },
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.11.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The owner organisation idenitifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -536,6 +590,30 @@
   "//provider-org": {
     "atleast_one": {
       "cases": [{ "paths": ["@ref", "narrative"] }]
+    },
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.10.13",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider organisation idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@provider-activity-id"],
+          "ruleInfo": {
+            "id": "1.4.13",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider-org activity idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        }
+      ]
     },
     "no_spaces": {
       "cases": [
@@ -582,6 +660,30 @@
             "severity": "warning",
             "category": "financial",
             "message": "The receiver-org activity idenitifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
+    },
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.15.13",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@receiver-activity-id"],
+          "ruleInfo": {
+            "id": "1.5.13",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver-org activity idenitifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -651,17 +753,33 @@
     "regex_matches": {
       "cases": [
         {
-          "regex": "[^\\/\\&\\|\\?]+",
-          "paths": ["organisation-identifier"]
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["organisation-identifier"],
+          "ruleInfo": {
+            "id": "1.12.13",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The organisation-idenitifer must not contain any of the symbols /, &, | or ?."
+          }
         },
         {
-          "regex": "[^\\/\\&\\|\\?]+",
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["recipient-org-budget/recipient-org/@ref"],
+          "ruleInfo": {
+            "id": "1.17.13",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The recipient organisation identifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.18.13",
             "severity": "warning",
-            "category": "information",
-            "message": "The {{matchedPathValue}} must not contain any of the symbols /, &, | or ?."
+            "category": "identifiers",
+            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -720,28 +838,52 @@
     "atleast_one": {
       "cases": [{ "paths": ["@ref", "narrative"] }]
     },
-    "no_spaces": {
+    "regex_matches": {
       "cases": [
         {
+          "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {
-            "id": "1.8.1",
+            "id": "1.8.13",
             "severity": "warning",
             "category": "participating",
-            "message": "The participating-org identifier should not start or end with spaces or newlines."
+            "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
           }
         },
         {
+          "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@activity-id"],
           "ruleInfo": {
-            "id": "1.9.1",
+            "id": "1.9.13",
             "severity": "warning",
             "category": "participating",
-            "message": "The participating-org activity identifier should not start or end with spaces or newlines."
+            "message": "The participating-org activity identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
     }
+  },
+  "no_spaces": {
+    "cases": [
+      {
+        "paths": ["@ref"],
+        "ruleInfo": {
+          "id": "1.8.1",
+          "severity": "warning",
+          "category": "participating",
+          "message": "The participating-org identifier should not start or end with spaces or newlines."
+        }
+      },
+      {
+        "paths": ["@activity-id"],
+        "ruleInfo": {
+          "id": "1.9.1",
+          "severity": "warning",
+          "category": "participating",
+          "message": "The participating-org activity identifier should not start or end with spaces or newlines."
+        }
+      }
+    ]
   },
   "//planned-disbursement": {
     "date_order": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -302,6 +302,7 @@
             "strict_sum": {
               "cases": [
                 {
+                  "condition": "count(sector[@vocabulary = '$1']) > 1",
                   "paths": ["sector[@vocabulary = '$1']/@percentage"],
                   "sum": 100,
                   "ruleInfo": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -191,7 +191,13 @@
         {
           "paths": ["sector/@percentage"],
           "min": 0.0,
-          "max": 100.0
+          "max": 100.0,
+          "ruleInfo": {
+            "id": "12.3.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "The sector percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
         },
         {
           "paths": ["capital-spend/@percentage"],

--- a/schema.json
+++ b/schema.json
@@ -1,451 +1,539 @@
 {
-    "title": "Ruleset",
-    "description": "A set of rules describing constraints on an XML document",
-    "type": "object",
-    "patternProperties": {
-        ".+": {
-            "properties": {
-                "no_more_than_one": {
-                    "description": "There must be no more than one element described by the given paths.",
+  "title": "Ruleset",
+  "description": "A set of rules describing constraints on an XML document",
+  "type": "object",
+  "patternProperties": {
+    ".+": {
+      "properties": {
+        "no_more_than_one": { "$ref": "#/definitions/no_more_than_one" },
+        "atleast_one": { "$ref": "#/definitions/atleast_one" },
+        "one_or_all": {
+          "description": "One must be present or all of the others must be.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "one": {
+                    "type": "string"
+                  },
+                  "all": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "only_one_of": {
+          "description": "Excluded elements must not coexist with selected elements, and only one of these elements must exist.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "excluded": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "if_then": { "$ref": "#/definitions/if_then" },
+        "dependent": {
+          "description": "If one of the provided paths exists, they must all exist.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "sum": {
+          "description": "The numerical sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "sum": {
+                    "type": "number"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "loop": {
+          "description": "Loops through different values of an attribute or element.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "foreach": {
+                    "type": "string"
+                  },
+                  "do": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
+                      "strict_sum": { "$ref": "#/definitions/strict_sum" },
+                      "if_then": { "$ref": "#/definitions/if_then" },
+                      "no_more_than_one": {
+                        "$ref": "#/definitions/no_more_than_one"
+                      },
+                      "atleast_one": { "$ref": "#/definitions/atleast_one" }
                     }
-                },
-                "atleast_one": {
-                    "description": "There must be at least one element described by the given paths.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "one_or_all": {
-                    "description": "One must be present or all of the others must be.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "one": {
-                                        "type": "string"
-                                    },
-                                    "all": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "only_one_of": {
-                    "description": "Excluded elements must not coexist with selected elements, and only one of these elements must exist.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "excluded": {
-                                        "type": "array",
-                                        "items": {"type":"string"}
-                                    },
-                                    "paths": {
-                                        "type": "array",
-                                        "items": {"type":"string"}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "dependent": {
-                    "description": "If one of the provided paths exists, they must all exist.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "sum": {
-                    "description": "The numerical sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "sum": {
-                                        "type": "number"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "loop": {
-                    "description": "Loops through different values of an attribute or element.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "foreach":{
-                                        "type":"string"
-                                    },
-                                    "do":{
-                                        "type": "object",
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "strict_sum": {
-                                                "type":"object",
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "cases":{
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "paths": {
-                                                                    "type": "array",
-                                                                    "items":{"type":"string"}
-                                                                },
-                                                                "sum": {
-                                                                    "type": "number"
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "subs":{
-                                        "type": "array",
-                                        "items": {"type":"string"}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "strict_sum": {
-                    "description": "The Decimal sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "sum": {
-                                        "type": "number"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "date_order": {
-                    "description": "The date matched by ``less`` must be less than the date matched by ``more``. If either of these dates is not found, the rule is ignored.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "less": {
-                                        "type": "string"
-                                    },
-                                    "more": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "date_now": {
-                    "description": "Date must not be more recent than the current date.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "date": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "time_limit": {
-                    "description": "Length must be under a year.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "start": {
-                                        "type": "string"
-                                    },
-                                    "end": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "between_dates": {
-                    "description": "Date must be within a defined time period.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "start": {
-                                        "type": "string"
-                                    },
-                                    "end": {
-                                        "type": "string"
-                                    },
-                                    "date": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "regex_matches": {
-                    "description": "The provided ``regex`` must match the text of all elements matched by ``paths``",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "regex": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "regex_no_matches": {
-                    "description": "The provided ``regex`` must match the text of none of the elements matched by ``paths``",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "regex": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "startswith": {
-                    "description": "The text of the each element matched by ``paths`` must start with the text of the element matched by ``start``",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "start": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "if_then": {
-                    "description": "The ``if`` condition must evaluate to true, otherwise ``then`` must evaluate to true.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "if": {
-                                        "type": "string"
-                                    },
-                                    "then": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "unique": {
-                    "description": "The text of each of the elements described by ``paths`` must be unique",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "range": {
-                    "description": "The value of each of the elements described by ``paths`` must be between the values of ```min`` and ```max```. Min/max can be excluded, to check that the value is at least or no more the specified key.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "min": {
-                                        "type": "number"
-                                    },
-                                    "max": {
-                                        "type": "number"
-                                    }
-                                }
-                            }
-                        }
-                    }                 
+                  },
+                  "subs": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
                 }
-            },
-            "additionalProperties": false
+              }
+            }
+          }
+        },
+        "strict_sum": { "$ref": "#/definitions/strict_sum" },
+        "date_order": {
+          "description": "The date matched by ``less`` must be less than the date matched by ``more``. If either of these dates is not found, the rule is ignored.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "condition": {
+                    "type": "string"
+                  },
+                  "less": {
+                    "type": "string"
+                  },
+                  "more": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "date_now": {
+          "description": "Date must not be more recent than the current date.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "date": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "time_limit": {
+          "description": "Length must be under a year.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "start": {
+                    "type": "string"
+                  },
+                  "end": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "between_dates": {
+          "description": "Date must be within a defined time period.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "start": {
+                    "type": "string"
+                  },
+                  "end": {
+                    "type": "string"
+                  },
+                  "date": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "regex_matches": {
+          "description": "The provided ``regex`` must match the text of all elements matched by ``paths``",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "regex": {
+                    "type": "string"
+                  },
+                  "idCondition": { "$ref": "#/definitions/idCondition" },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "regex_no_matches": {
+          "description": "The provided ``regex`` must match the text of none of the elements matched by ``paths``",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "regex": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "startswith": {
+          "description": "The text of the each element matched by ``paths`` must start with the text of the element matched by ``start``",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "start": {
+                    "type": "string"
+                  },
+                  "idCondition": {
+                    "$ref": "#/definitions/idCondition"
+                  },
+                  "prefix": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "separator": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "unique": {
+          "description": "The text of each of the elements described by ``paths`` must be unique",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "range": {
+          "description": "The value of each of the elements described by ``paths`` must be between the values of ```min`` and ```max```. Min/max can be excluded, to check that the value is at least or no more the specified key.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "min": {
+                    "type": "number"
+                  },
+                  "max": {
+                    "type": "number"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "no_spaces": {
+          "description": "The text of each of the elements described by ``paths`` should not start or end with spaces or newlines",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
         }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "idCondition": {
+      "type": "string",
+      "enum": ["NOT_EXISTING_ORG_ID_PREFIX", "NOT_EXISTING_ORG_ID"]
     },
-    "additionalProperties": false
+    "ruleInfo": {
+      "type": "object",
+      "description": "Information about the rule used by the validator",
+      "required": ["id", "severity", "category", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier of the error",
+          "examples": ["9.26.1", "9.42.1"]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["critical", "error", "warning"],
+          "description": "The severity level of the error"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "iati",
+            "identifiers",
+            "organisation",
+            "information",
+            "participating",
+            "geo",
+            "classifications",
+            "financial",
+            "documents",
+            "relations",
+            "performance"
+          ],
+          "description": "The category of the validation error"
+        },
+        "message": {
+          "type": "string",
+          "description": "The informational message about the validation error"
+        }
+      }
+    },
+    "no_more_than_one": {
+      "description": "There must be no more than one element described by the given paths.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "cases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "paths": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "condition": {
+                "type": "string"
+              },
+              "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+            }
+          }
+        }
+      }
+    },
+    "atleast_one": {
+      "description": "There must be at least one element described by the given paths.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "paths": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "condition": {
+                "type": "string"
+              },
+              "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+            }
+          }
+        }
+      }
+    },
+    "if_then": {
+      "description": "The ``if`` condition must evaluate to true, otherwise ``then`` must evaluate to true.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "if": {
+                "type": "string"
+              },
+              "then": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+            }
+          }
+        }
+      }
+    },
+    "strict_sum": {
+      "description": "The Decimal sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "paths": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "sum": {
+                "type": "number"
+              },
+              "condition": {
+                "type": "string"
+              },
+              "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/schema.json
+++ b/schema.json
@@ -433,6 +433,20 @@
         "message": {
           "type": "string",
           "description": "The informational message about the validation error"
+        },
+        "link": {
+          "type": "object",
+          "description": "Link to related website guidance on the error",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "Full url to the guidance"
+            },
+            "path": {
+              "type": "string",
+              "description": "Path to be added on the the base url of the iati standard documentation e.g. https://iatistandard.org/en/iati-standard/{version}/{path}"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Summary
- As part of the **V2 Validator work**, the JSON-based rules have been enhanced and some additional checks and feedback messages have been added in line with the IATI Standard. See `SPEC_JS <SPEC_JS.rst>`_ for more detail.
- This PR is planned to be merged the week of 13 September.

## Details

- prettier format
- initial updates for validatorV2
- Add 102.1.1
- 1.1.1 rule added
- fix location of 102.1.1
- 1.1.3 reporting-org to iati-identifier check
- 1.1.21 identifiers rule added
- 12.3.1 sector % range
- 2.1.2 sector percentage sums
- 6.14.1 and 6.13.1 policy-marker attribute rules
- 6.2.2 sector requirement
- 6.7.2 sector
- 6.6.2 rule
- 7.8.1 rule added for currency
- 107.1.1 default-aid-type
- 12.1.1 recipient-region/country range
- 12.2.1 capital-spend and budget-item range
- 3.1.2 recipient-country percentage
- 3.4.2 recipient-region/country percentage sum
- organisation identifier prefix checks against ORG-ID
- 7.5.3 budget period
- 7.5.2 value-date check
- 8.X.3 result indicator value omission
- 8.6.3 period date_order
- 1.X.1 no spaces or newlines rules
- 1.X.13 regex_matches no special characters
- adding ruleInfo to many existing rules
- result indicator value number type check
- 7.9.1 7.9.2 7.9.4 country budget item percentages
- 107.1.2 default aid type limit
- 107.2.1 complete
- 107.2.2 complete
- 2.1.1 sector percentage requirements
- 2.1.4 sector vocab percentage requirements
- refactor to use or inside [] for some xpaths
- 4.3.1 4.4.1 title and description narrative checks
- 3.6.2, 3.7.1, 3.7.2 recipient location rules
- 3.4.1 complete
- 3.1.4 3.4.4 added, various small fixes
- 3.1.1 added
- add  @vocabulary = '' as option
- more specific name
- add 7.8.2 currency check
- remove 1.X.8 and 1.X.13 rules that aren't in V1
- add idConditions to identifier checks
- 3.4.2 add recipient-country into condition
- remove 1yr budget limit for planned-disbursement 7.5.3, added in error
- add paths to if_then rules for additional context generation in the output
- fix message for 3.4.1
- fix incorrectly placed rules in JSON
- schema updates and push to redis workflow
- add JS implementation specifications
- remove 7.5.2 as it duplicates Schema check
- add job to trigger csv update on rule tracker repo
- fix spelling errors with identifier
- remove duplicative rule 1.1.1 and update message for 1.1.21
- fix 107.2.2 by moving to transaction level evaluation
- add commit sha to redis cache
- use file commit sha instead of current commit sha
- try different format
- add -- separator for filepath
- add fetch-depth
- add support for guidance links
- push rulesets to PROD redis-cacher
- updates for validator v2
- remove reference to Readme.md
