### PR TITLE
Validator V2 Updates - v2.02

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,13 @@
 
 name: CI_version-2.02
 
+env:
+  DEV_DEFAULT_KEY: ${{ secrets.DEV_CACHER_DEFAULT_KEY }} # Azure Functions default API Key for Redis-cacher
+  VERSION: 2.02
+
 on:
   push:
-    branches: [version-2.02]
+    branches: [version-2.02, v2.02/validatorV2]
   pull_request:
     branches: [version-2.02]
 
@@ -48,3 +52,26 @@ jobs:
         run: |
           python -m jsonschema -i rulesets/standard.json schema.json
           ./meta_tests.sh python testrules.py
+
+  cache-ruleset:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: POST ruleset/standard.json to redis-cacher
+        run: |
+          HTTP_CODE=$(curl --write-out "%{http_code}\n" \
+          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION \
+          --header 'x-functions-key: '$DEV_DEFAULT_KEY \
+          --header 'Content-Type: application/json' \
+          --data-binary '@./rulesets/standard.json' \
+          --output curl_out.txt \
+          --silent )
+          echo $HTTP_CODE
+          if [[ $HTTP_CODE != '200' ]] ; then
+            echo "Reponse is not 200 from redis-cacher, check error logs"
+            cat curl_out.txt
+            exit 1
+          fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,33 +86,33 @@ jobs:
             exit 1
           fi
 
-  cache-ruleset-prod:
-    needs: cache-ruleset-dev
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Number of commits to fetch. 0 indicates all history for all branches and tags.
-          fetch-depth: 0
+  # cache-ruleset-prod:
+  #   needs: cache-ruleset-dev
+  #   runs-on: ubuntu-latest
+  #   if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         # Number of commits to fetch. 0 indicates all history for all branches and tags.
+  #         fetch-depth: 0
 
-      - name: POST ruleset/standard.json to func-iati-redis-cacher-PROD
-        run: |
-          FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
-          echo $FILE_COMMIT_SHA
-          HTTP_CODE=$(curl --write-out "%{http_code}\n" \
-          --location --request POST 'https://func-iati-redis-cacher-prod.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \
-          --header 'x-functions-key: '$PROD_DEFAULT_KEY \
-          --header 'Content-Type: application/json' \
-          --data-binary '@./rulesets/standard.json' \
-          --output curl_out.txt \
-          --silent )
-          echo $HTTP_CODE
-          if [[ $HTTP_CODE != '200' ]] ; then
-            echo "Reponse is not 200 from func-iati-redis-cacher-PROD, check error logs"
-            cat curl_out.txt
-            exit 1
-          fi
+  #     - name: POST ruleset/standard.json to func-iati-redis-cacher-PROD
+  #       run: |
+  #         FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
+  #         echo $FILE_COMMIT_SHA
+  #         HTTP_CODE=$(curl --write-out "%{http_code}\n" \
+  #         --location --request POST 'https://func-iati-redis-cacher-prod.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \
+  #         --header 'x-functions-key: '$PROD_DEFAULT_KEY \
+  #         --header 'Content-Type: application/json' \
+  #         --data-binary '@./rulesets/standard.json' \
+  #         --output curl_out.txt \
+  #         --silent )
+  #         echo $HTTP_CODE
+  #         if [[ $HTTP_CODE != '200' ]] ; then
+  #           echo "Reponse is not 200 from func-iati-redis-cacher-PROD, check error logs"
+  #           cat curl_out.txt
+  #           exit 1
+  #         fi
 
   update-rule-tracker:
     needs: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,7 @@ name: CI_version-2.02
 
 env:
   DEV_DEFAULT_KEY: ${{ secrets.DEV_CACHER_DEFAULT_KEY }} # Azure Functions default API Key for Redis-cacher
+  PROD_DEFAULT_KEY: ${{ secrets.PROD_CACHER_DEFAULT_KEY }} # Azure Functions default API Key for Redis-cacher
   VERSION: 2.02
 
 on:
@@ -53,7 +54,7 @@ jobs:
           python -m jsonschema -i rulesets/standard.json schema.json
           ./meta_tests.sh python testrules.py
 
-  cache-ruleset:
+  cache-ruleset-dev:
     needs: build
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
@@ -63,7 +64,7 @@ jobs:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           fetch-depth: 0
 
-      - name: POST ruleset/standard.json to redis-cacher
+      - name: POST ruleset/standard.json to func-iati-redis-cacher-dev
         run: |
           FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
           echo $FILE_COMMIT_SHA
@@ -76,7 +77,35 @@ jobs:
           --silent )
           echo $HTTP_CODE
           if [[ $HTTP_CODE != '200' ]] ; then
-            echo "Reponse is not 200 from redis-cacher, check error logs"
+            echo "Reponse is not 200 from func-iati-redis-cacher-dev, check error logs"
+            cat curl_out.txt
+            exit 1
+          fi
+
+  cache-ruleset-prod:
+    needs: cache-ruleset-dev
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
+
+      - name: POST ruleset/standard.json to func-iati-redis-cacher-PROD
+        run: |
+          FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
+          echo $FILE_COMMIT_SHA
+          HTTP_CODE=$(curl --write-out "%{http_code}\n" \
+          --location --request POST 'https://func-iati-redis-cacher-prod.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \
+          --header 'x-functions-key: '$PROD_DEFAULT_KEY \
+          --header 'Content-Type: application/json' \
+          --data-binary '@./rulesets/standard.json' \
+          --output curl_out.txt \
+          --silent )
+          echo $HTTP_CODE
+          if [[ $HTTP_CODE != '200' ]] ; then
+            echo "Reponse is not 200 from func-iati-redis-cacher-PROD, check error logs"
             cat curl_out.txt
             exit 1
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,11 +59,16 @@ jobs:
     if: ${{ github.event_name == 'push' }} # only push to the redis cache on PUSH
     steps:
       - uses: actions/checkout@v2
+        with:
+          # Number of commits to fetch. 0 indicates all history for all branches and tags.
+          fetch-depth: 0
 
       - name: POST ruleset/standard.json to redis-cacher
         run: |
+          FILE_COMMIT_SHA=$(git log -1 --format='%H' -- './rulesets/standard.json')
+          echo $FILE_COMMIT_SHA
           HTTP_CODE=$(curl --write-out "%{http_code}\n" \
-          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION \
+          --location --request POST 'https://func-iati-redis-cacher-dev.azurewebsites.net/api/pvt/cache?key=ruleset'$VERSION'&commitsha='$FILE_COMMIT_SHA \
           --header 'x-functions-key: '$DEV_DEFAULT_KEY \
           --header 'Content-Type: application/json' \
           --data-binary '@./rulesets/standard.json' \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,12 @@ env:
 
 on:
   push:
+    paths-ignore: # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - "**/*.rst"
     branches: [version-2.02, v2.02/validatorV2]
   pull_request:
+    paths-ignore: # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
+      - "**/*.rst"
     branches: [version-2.02]
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,3 +75,15 @@ jobs:
             cat curl_out.txt
             exit 1
           fi
+
+  update-rule-tracker:
+    needs: build
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }} # only push to the rule tracker on PUSH
+    steps:
+      - name: "Trigger update of rule tracker repo .csv"
+        run: |
+          curl -X POST https://api.github.com/repos/IATI/validator-rule-tracker/dispatches \
+          -H 'Accept: application/vnd.github.everest-preview+json' \
+          -u ${{ secrets.NJO_PAT }} \
+          --data '{"event_type": "update", "client_payload": { "resourceName": "rulesets", "repo": "'"$GITHUB_REPOSITORY"'", "sha": "'"$GITHUB_SHA"'"}}'

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist
 pyenv*
 doc/_build
 build
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -12,18 +12,18 @@ IATI-Rulesets
 Introduction
 ============
 
-This is the source repository for the rulesets, more general information can be found on the IATIStandard website: https://iatistandard.org/rulesets/
+This is the source repository for the rulesets, more general information can be found on the IATI Standard website: https://iatistandard.org/en/iati-standard/202/rulesets/
 
-These rulesets are part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see https://iatistandard.org/developer/ssot/
+These rulesets are part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see https://iatistandard.org/en/guidance/developer/ssot/
 
 
-As part of the **V1 Validator work**, the JSON-based rules have been migrated to an XSLT-based system, and some additional checks and feedback messages have been added in line with the IATI Standard.
-Please see D4D's `IATI data validator <https://github.com/data4development/IATI-data-validator>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
-IATI's Reference Site will be updated as the testing period progresses. Please refer to the new Validator's `XSLT-based Ruleset <https://github.com/data4development/IATI-Rulesets>`_ repository for an up-to-date version of each rule's narrative.
+As part of the **V1 Validator work**, the JSON-based rules were migrated to an XSLT-based system, and some additional checks and feedback messages have been added in line with the IATI Standard.
+Please see `IATI Validator Actual <https://github.com/IATI/IATI-Validator-Actual>`_  repository for information about the V1 tool and to report bugs, issues, and other feedback.
+Please refer to the new Validator's `XSLT-based Ruleset <https://github.com/IATI/IATI-Rulesets#master>`_ repository for an up-to-date version of each rule's narrative.
 Email us on support@iatistandard.org for further clarification.
 
 As part of the **V2 Validator work**, the JSON-based rules have been enhanced and some additional checks and feedback messages have been added in line with the IATI Standard. See `SPEC_JS <SPEC_JS.rst>`_ for more detail.
-A new JavaScript (Node) implementation of the Ruleset validator has been developed as well. Please see IATI's `IATI js validator api <https://github.com/IATI/js-validator-api>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
+A new JavaScript (Node) implementation of the Ruleset validator has been developed as well. Please see `IATI Validator API <https://github.com/IATI/js-validator-api>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
 Email us on support@iatistandard.org for further clarification.
 
 Information for developers
@@ -96,7 +96,7 @@ Tests for Testers
 Different Rulesets
 ==================
 
-* ``standard.json`` is a ruleset that tries to describe compliance to the standard
+* ``standard.json`` is a ruleset that tries to describe compliance to the standard, this is used by the `IATI js validator api <https://github.com/IATI/js-validator-api>`_
 * ``dfid.json`` is a more comprehensive set of rules based on DFID's requirements for organisations it works with
 * ``ti-fallbacks.json`` finds problems with data that had to be worked around (using fallbacks) in transparency indicator tests
 
@@ -107,3 +107,4 @@ Rules not describable by a Ruleset
 
 * Testing whether identifier are correct (e.g. uniqueness etc) - this requires information outside the scope of a single activity/file, whereas currently the rulesets operate in just this context. This may change in the future.
 
+Both the above rules are included as part of the `IATI js validator api <https://github.com/IATI/js-validator-api>`_. Please see that repository for more information.

--- a/README.rst
+++ b/README.rst
@@ -1,20 +1,30 @@
 IATI-Rulesets
 ^^^^^^^^^^^^^
-
 .. image:: https://github.com/IATI/IATI-Rulesets/workflows/CI_version-2.02/badge.svg
     :target: https://github.com/IATI/IATI-Rulesets/actions
-.. image:: https://requires.io/github/IATI/IATI-Rulesets/requirements.svg?branch=version-2.01
-    :target: https://requires.io/github/IATI/IATI-Rulesets/requirements/?branch=version-2.01
+
+.. image:: https://requires.io/github/IATI/IATI-Rulesets/requirements.svg?branch=version-2.02
+    :target: https://requires.io/github/IATI/IATI-Rulesets/requirements/?branch=version-2.02
     :alt: Requirements Status
 .. image:: https://img.shields.io/badge/license-MIT-blue.svg
-    :target: https://github.com/IATI/IATI-Rulesets/blob/version-2.01/LICENSE
+    :target: https://github.com/IATI/IATI-Rulesets/blob/version-2.02/LICENSE
 
 Introduction
 ============
 
-This is the source repository for the rulesets, more general information can be found on the IATIStandard website: http://iatistandard.org/rulesets/
+This is the source repository for the rulesets, more general information can be found on the IATIStandard website: https://iatistandard.org/rulesets/
 
-These rulesets are part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see http://iatistandard.org/developer/ssot/
+These rulesets are part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see https://iatistandard.org/developer/ssot/
+
+
+As part of the **V1 Validator work**, the JSON-based rules have been migrated to an XSLT-based system, and some additional checks and feedback messages have been added in line with the IATI Standard.
+Please see D4D's `IATI data validator <https://github.com/data4development/IATI-data-validator>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
+IATI's Reference Site will be updated as the testing period progresses. Please refer to the new Validator's `XSLT-based Ruleset <https://github.com/data4development/IATI-Rulesets>`_ repository for an up-to-date version of each rule's narrative.
+Email us on support@iatistandard.org for further clarification.
+
+As part of the **V2 Validator work**, the JSON-based rules have been enhanced and some additional checks and feedback messages have been added in line with the IATI Standard. See `SPEC_JS <SPEC_JS.rst>`_ for more detail.
+A new JavaScript (Node) implementation of the Ruleset validator has been developed as well. Please see IATI's `IATI js validator api <https://github.com/IATI/js-validator-api>`_  repository for information about the new tool and to report bugs, issues, and other feedback.
+Email us on support@iatistandard.org for further clarification.
 
 Information for developers
 ==========================
@@ -36,7 +46,17 @@ A ruleset is a JSON file which applies different rules to various paths in diffe
         "//iati-activity": {
             "atleast_one": {
                 "cases": [
-                    { "paths": ["iati-identifier"] }
+                    { "paths": ["iati-identifier"],
+                      "ruleInfo": {
+                        "id": "6.11.1",
+                        "severity": "error",
+                        "category": "information",
+                        "message": "The activity must have a planned start date or an actual start date.",
+                        "link": {
+                            "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+                        } 
+                      }
+                    }
                 ]
             }
         }
@@ -44,11 +64,16 @@ A ruleset is a JSON file which applies different rules to various paths in diffe
 
 Here we have a context: ``iati-activity``, with a single name rule `atleast_one` which is applied in a number of cases - here just one, with a single path.
 
-A more thorough description of this, along with a list of all rule names can be found in the `Spec <https://github.com/IATI/IATI-Rulesets/blob/version-2.02/SPEC.rst>`_.
+The ``ruleInfo`` object includes metadata about the rule which is used in the `IATI js validator api <https://github.com/IATI/js-validator-api>`_
 
+A more thorough description of this, along with a list of all rule names can be found in the `Spec <SPEC_JS.rst>`_.
+
+A description of the earlier Python based implementation can be found in the `Spec <SPEC.rst>`_.
 
 Ruleset Tester
 ==============
+
+**NOTE** : The following Python tests have not been updated for the new JavaScript implementation of the rulesets and therefore are not comprehensive in testing IATI XML. Use the `IATI js validator api <https://github.com/IATI/js-validator-api>`_ for comprehensive testing.
 
 A program is required to test whether a given xml file conforms to the rules in a ruleset JSON file. The rulesets is designed such that implementations of this can be made in multiple programming languages, so long as they implement the `Spec <https://github.com/IATI/IATI-Rulesets/blob/version-2.02/SPEC.rst>`_.
 

--- a/README.rst
+++ b/README.rst
@@ -38,7 +38,7 @@ This tool supports Python 3.x. To use this script, we recommend the use of a vir
 Ruleset Structure
 =================
 
-A ruleset is a JSON file which applies different rules to various paths in different elements. Structure:
+A ruleset is a JSON file which applies different rules to various paths in different elements. Example Structure:
 
 .. code-block:: json
     
@@ -46,29 +46,55 @@ A ruleset is a JSON file which applies different rules to various paths in diffe
         "//iati-activity": {
             "atleast_one": {
                 "cases": [
-                    { "paths": ["iati-identifier"],
-                      "ruleInfo": {
-                        "id": "6.11.1",
-                        "severity": "error",
-                        "category": "information",
-                        "message": "The activity must have a planned start date or an actual start date.",
-                        "link": {
-                            "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
-                        } 
-                      }
+                    { 
+                        "paths": ["iati-identifier"],
+                        "ruleInfo": {
+                            "id": "6.11.1",
+                            "severity": "error",
+                            "category": "information",
+                            "message": "The activity must have a planned start date or an actual start date.",
+                            "link": {
+                                "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+                            } 
+                        }
+                    }
+                ]
+            },
+            "range": {
+                "cases": [
+                    {
+                        "paths": ["capital-spend/@percentage"],
+                        "min": 0.0,
+                        "max": 100.0,
+                        "ruleInfo": {
+                            "id": "12.2.1",
+                            "severity": "error",
+                            "category": "financial",
+                            "message": "The percentage value must be between 0.0 and 100.0 (inclusive).",
+                            "link": {
+                                "path": "activity-standard/iati-activities/iati-activity/capital-spend/"
+                            }
+                        }
                     }
                 ]
             }
         }
     }
 
-Here we have a context: ``iati-activity``, with a single name rule `atleast_one` which is applied in a number of cases - here just one, with a single path.
+Here we have a context: ``iati-activity``, with a two named rules `atleast_one` and `range` which is applied in a number of cases - here just one each, with a single path each.
 
-The ``ruleInfo`` object includes metadata about the rule which is used in the `IATI js validator api <https://github.com/IATI/js-validator-api>`_
+The full JSON Schema is defined in `<schema.json>`__. 
 
 A more thorough description of this, along with a list of all rule names can be found in the `Spec <SPEC_JS.rst>`_.
 
 A description of the earlier Python based implementation can be found in the `Spec <SPEC.rst>`_.
+
+The ``ruleInfo`` object includes metadata about the rule which is used in the `IATI js validator api <https://github.com/IATI/js-validator-api>`_.
+
+The ``link`` object can contain 2 possible keys which represent the Guidance Links for the rule:
+* ``url`` is a full URL to the guidance
+* ``path`` is the path to be added to the end of the reference documentation url for the version of standard. (e.g. https://iatistandard.org/en/iati-standard/{version}/{path})
+
 
 Ruleset Tester
 ==============
@@ -108,3 +134,14 @@ Rules not describable by a Ruleset
 * Testing whether identifier are correct (e.g. uniqueness etc) - this requires information outside the scope of a single activity/file, whereas currently the rulesets operate in just this context. This may change in the future.
 
 Both the above rules are included as part of the `IATI js validator api <https://github.com/IATI/js-validator-api>`_. Please see that repository for more information.
+
+GitHub Actions workflows
+=========================
+
+``.github/workflows/main.yml`` does a few things when new code is pushed to  version-2.0X branches. 
+
+* Runs flake8 linting 
+* Tests that ``rulesets/standard.json`` adheres to the JSON schema defined in ``schema.json``
+* Runs `<meta_tests.sh>`__ 
+* Pushes ``rulesets/standard.json`` to the Redis cache used by the `IATI js validator api <https://github.com/IATI/js-validator-api>`__
+* Triggers a workflow to update the .csv Validator rules in `Validator Rule Tracker <https://github.com/IATI/validator-rule-tracker>`__

--- a/SPEC_JS.rst
+++ b/SPEC_JS.rst
@@ -1,8 +1,8 @@
 
-IATI Ruleset Spec
+IATI Ruleset Spec - JS Edition
 =================
 
-An IATI Ruleset is a JSON document. The structure is described below.
+An IATI Ruleset is a JSON document. The structure is described below. This specification is specific to the new JavaScript implementation of the Ruleset validator which is part of the 2021 Validator.
 
 A `JSON schema <https://github.com/IATI/IATI-Rulesets/blob/version-2.02/schema.json>`_ is availible to test that the structure of a Ruleset is correct.
 
@@ -25,7 +25,11 @@ Where ``CONTEXT`` is an xpath expression. This will be used to select the XML el
 The possible keys in a case dictionary are:
 
 ``condition``
-    An xpath string. If this evaluates to True, the rule will be ignored.
+    An xpath string. If this evaluates to False, the rule will be ignored.
+``idCondition``
+    If this evaluates to False, the rule will be ignored.
+    NOT_EXISTING_ORG_ID - Checks that values in ``paths`` are NOT an existing Publisher Organisation ID from the Registry
+    NOT_EXISTING_ORG_ID_PREFIX - Checks that values in ``paths`` are NOT prefixed with an existing Publisher Organisation ID from the Registry
 ``eval``
     An xpath string. Can evaluate to True or False.
 ``paths``
@@ -37,7 +41,7 @@ The possible keys in a case dictionary are:
 ``regex``
     A string containing a perl style regular expression.
 ``sum``
-    A number.
+    A number that is the expected sum.
 ``excluded``
     An array of xpath strings. Evaluate which elements should not coexist with other elements.
 ``date``
@@ -51,108 +55,112 @@ The possible keys in a case dictionary are:
 ``all``
     A string containing the condition that must be met for all elements if ``one`` is not met.
 ``foreach``
-    An array of xpath strings. Containing a set of xpaths to be evaluated under a different rule.
+    An xpath string to group the loop by and evalute each ``do`` with the substituted result. 
 ``do``
-    An array of rules. To evaluate with ``foreach``.
+    An array of rules. To evaluate with ``foreach``. Available rules include: ``strict_sum``, ``if_then``, ``atleast_one``, ``no_more_than_one`` 
 ``subs``
-    An array of xpath strings. These are to be evaluated with the rules in ``do``.
+    An array of keys where the value matched in ``foreach`` should be substituded for the ``$1`` values in the ``do`` cases.
+``prefix``
+    An array of xpath strings. The matches of which, contain the possible prefixes for a path. If set to "ORG-ID-PREFIX" for startsWith, checks against provided list of prefixes in ``idSets.ORG-ID-PREFIX``. ``idSets`` are passed to the Rule evaluation code.
 
 Rule Names
 ----------
 
-
 **Rule names are listed in bold**
-    Keys: The keys for each rule are then listed.
+    Keys: The keys for each rule are then listed. The are listed in **snake-case**/**camel-case**.
 
     Followed by a brief description of the rule's function.
 
 
-**no_more_than_one**
+**no_more_than_one**/**noMoreThanOne**
     Keys: ``condition``, ``paths``
 
     There must be no more than one element described by the given paths.
 
-**atleast_one**
+**atleast_one**/**atLeastOne**
     Keys: ``condition``, ``paths``
 
     There must be at least one element described by the given paths.
 
-**only_one_of**
+**only_one_of**/**onlyOneOf**
     Keys: ``excluded``, ``paths``
 
     If there's a match of the elements in ``excluded``, there must not be any matches in ``paths``, if there are no matches in ``excluded``, there must be exactly one element from ``paths``.
 
-**one_or_all**
+**one_or_all**/**oneOrAll**
     Keys: ``one``, ``all``
 
-    ``one`` must exist otherwise ``all`` other attributes or elements must exist.
+    ``one`` must exist otherwise ``all`` other attributes or elements must exist. 
 
-**dependent**
+**dependent**/**NOT IMPLEMENTED IN JS**
     Keys: ``condition``, ``paths``
 
     If one of the provided paths exists, they must all exist.
 
-**sum**
+**sum**/**sum**
     Keys: ``condition``, ``paths``, ``sum``
 
     The numerical sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key
 
-**date_order**
+**date_order**/**dateOrder**
     Keys: ``condition``, ``less``, ``more``
 
-    The date matched by ``less`` must not be after the date matched by ``more``. If either of these dates is not found, the rule is ignored.
-
-**date_now**
+    The date matched by ``less`` must not be after the date matched by ``more``. If they are equal, the are valid. If either of these dates is not found, the rule is ignored.
+    https://drive.google.com/file/d/1-R-xGMCrAKiadMBIHsNc4Xvl75CB0IV1/view
+    
+**date_now**/**dateNow**
     Keys: ``date``
 
     The ``date`` must not be after the current date.
 
-**time_limit**
+**time_limit**/**timeLimit**
     Keys: ``start``, ``end``
 
     The difference between the ``start`` date and the ``end`` date must not be greater than a year.
 
-**between_dates**
+**between_dates**/**betweenDates**
     Keys: ``date``, ``start``, ``end``
 
     The ``date`` must be between the ``start`` and ``end`` dates.
 
-**regex_matches**
+**regex_matches**/**regexMatches**
+    Keys: ``condition``, ``idCondition``, ``paths``, ``regex``
+
+    The provided ``regex`` must match the text of all elements matched by ``paths``. ``idCondition`` is also an optional parameter.
+
+**regex_no_matches**/**regexNoMatches**
     Keys: ``condition``, ``paths``, ``regex``
 
-    The provided ``regex`` must match the text of all elements matched by ``paths``
+    The provided ``regex`` must match the text of none of the elements matched by ``paths``.
 
-**regex_no_matches**
-    Keys: ``condition``, ``paths``, ``regex``
+**startswith**/**startsWith**
+    Keys: ``condition``, ``idCondition``, ``paths``, ``start``, ``separator``
 
-    The provided ``regex`` must match the text of none of the elements matched by ``paths``
+    The text of each element matched by ``paths`` must start with the text of one of the elements matched by ``prefix`` (or a list of prefixed provided in ``idSets``) with an optional ``separator`` in between
+    ``prefix````separator````pathMatchText``. ``idCondition`` is also an optional parameter.
 
-**startswith**
-    Keys: ``condition``, ``paths``, ``start``
-
-    The text of each element matched by ``paths`` must start with the text of the element matched by ``start``
-
-**unique**
+**unique**/**unique**
     Keys: ``condition``, ``paths``
 
     The text of each of the elements described by ``paths`` must be unique
 
-**evaluates_to_true**
-    Keys: ``cases``, ``eval``
-
-    Each expression defined in ``eval`` must resolve to true
-
-**if_then**
-    Keys: ``condition``, ``cases``, ``if``, ``then``
+**if_then**/**ifThen**
+    Keys: ``condition``, ``cases``, ``if``, ``then``, ``paths``
 
     If the condition evaluated in ``if`` is true, then ``then`` must resolve to true as well
+    ``paths`` can be defined to provide additional context data in the output if a rule fails, but had no bearing on the pass/fail of the rule 
 
-**loop**
+**loop**/**loop**
     Keys: ``foreach``, ``do``, ``cases``, ``subs``
 
     All elements in ``foreach`` are evaluated under the rules inside ``do``
 
-**strict_sum**
+**strict_sum**/**strictSum**
     Keys: ``paths``, ``sum``
 
     The decimal sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key
+
+**no_spaces**/**noSpaces**
+    Keys: ``paths``
+
+    The text of each of the elements described by ``paths`` should not start or end with spaces or newlines 

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -24,7 +24,7 @@ def simplify_xpath(xpath):
 
 def rule_link(rule_id):
     """Returns a Github link given a rule ID"""
-    default_url = 'https://github.com/IATI/IATI-Rulesets/blob/v2.03/validatorV2/rulesets/standard.json'
+    default_url = 'https://github.com/IATI/IATI-Rulesets/blob/v2.02/validatorV2/rulesets/standard.json'
     base_url = default_url + '#L'
     file_dirname = os.path.dirname(__file__)
     if 'IATI-Rulesets' in file_dirname:

--- a/iatirulesets/text.py
+++ b/iatirulesets/text.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
+import os
 import re
-import copy
 
 
 def human_list(other_paths, separator='or'):
@@ -18,107 +18,62 @@ def extract_from_expr(expr):
     return expr
 
 
-def rules_text(rules, reduced_path, show_all=False):
+def simplify_xpath(xpath):
+    return re.sub(r'\[[^\]]*\]', '', xpath)
+
+
+def rule_link(rule_id):
+    """Returns a Github link given a rule ID"""
+    default_url = 'https://github.com/IATI/IATI-Rulesets/blob/v2.03/validatorV2/rulesets/standard.json'
+    base_url = default_url + '#L'
+    file_dirname = os.path.dirname(__file__)
+    if 'IATI-Rulesets' in file_dirname:
+        rule_path = os.path.abspath(os.path.join(file_dirname, '../rulesets/standard.json'))
+    else:
+        rule_path = os.path.abspath(os.path.join(file_dirname, '../IATI-Rulesets/rulesets/standard.json'))
+    with open(rule_path) as standard_json:
+        for num, line in enumerate(standard_json, 1):
+            if '"' + rule_id + '"' in line:
+                return base_url + str(num)
+    return default_url
+
+
+def rules_text(rules, reduced_path=None):
+    possible_path_keys = ['less', 'more', 'start', 'end', 'date', 'one']
     out = []
     for rule in rules:
         cases = rules[rule]['cases']
         for case in cases:
-            simplify_xpath = lambda x: re.sub(r'\[[^\]]*\]', '', x)
-            if 'paths' in case:
-                for case_path in case['paths']:
-                    # Don't forget [@ ]
-                    if show_all or simplify_xpath(case_path) == reduced_path:
-                        other_paths = copy.deepcopy(case['paths'])
-                        other_paths.remove(case_path)
-                        if rule == 'only_one':
-                            out.append('``{0}`` must be present only once.'.format(case_path))
-                            if other_paths:
-                                out.append('``{0}`` must not be present if ``{1}`` are present.'.format(case_path, human_list(other_paths)))
-                                break
-                        elif rule == 'atleast_one':
-                            cond = case.get('condition', None)
-                            cond = '.' if not cond else ' if {}'.format(cond)
-
-                            if other_paths:
-                                out.append('Either ``{0}`` or ``{1}`` must be present{2}'.format(case_path, human_list(other_paths), cond))
-                                break
-                            else:
-                                out.append('``{0}`` must be present{1}'.format(case_path, cond))
-
-                        elif rule == 'only_one_of':
-                            out.append('``{0}`` must not be present alongisde ``{1}``.'.format(case_path, human_list(case['excluded'], 'and')))
-                        elif rule == 'startswith':
-                            out.append('``{0}`` should start with the value in ``{1}``'.format(case_path, case['start']))
-                        elif rule == 'regex_matches':
-                            out.append('``{0}`` should match the regex ``{1}``'.format(case_path, case['regex']))
-                        elif rule == 'no_more_than_one':
-                            if other_paths:
-                                out.append('There must be no more than one element or attribute matched at ``{0}`` or ``{1}``.'.format(case_path, human_list(other_paths)))
-                            else:
-                                out.append('There must be no more than one element or attribute matched at ``{0}``.'.format(case_path))
-                        elif rule == 'sum':
-                            sum_total = case['sum']
-                            if other_paths:
-                                out.append('The sum of values matched at ``{0}`` and ``{1}`` must be ``{2}``.'.format(case_path, human_list(other_paths, 'and'), sum_total))
-                                break
-                            else:
-                                out.append('The sum of values matched at ``{0}`` must be ``{2}``.'.format(case_path, sum_total))
-                        elif rule == 'strict_sum':
-                            out.append('The sum of values matched at ``{0}`` must be ``{1}``.'.format(case_path, case['sum']))
-                        elif rule == 'range':
-                            min_val = case.get('min')
-                            max_val = case.get('max')
-                            if min_val is not None or max_val is not None:
-                                # only proceed if one of the two exists
-                                txt = 'The value of each of the elements described by ``{0}`` must be'.format(case_path)
-                                txt += ' at least ``{0}``'.format(min_val) if min_val is not None else ''
-                                txt += ' no more than ``{0}``'.format(max_val) if max_val is not None else ''
-                                txt += ' (inclusive).'
-                                out.append(txt)
-                        else:
-                            print('Not implemented', rule, reduced_path)
-            else:
-                # rather than checking line-by-line wether reduced_path is in either one of the specific cases
-                # we do a generic check to assess we're rendering the right rule for the right element
-                if rule == 'date_order':
-                    if show_all or reduced_path == simplify_xpath(case['less']) or reduced_path == simplify_xpath(case['more']):
-                        if case['less'] == 'NOW':
-                            out.append('``{0}`` must not be in the past.'.format(case['more']))
-                        elif case['more'] == 'NOW':
-                            out.append('``{0}`` must not be in the future.'.format(case['less']))
-                        else:
-                            out.append('``{0}`` must be before or the same as ``{1}``'.format(case['less'], case['more']))
-
-                elif rule == 'time_limit':
-                    if show_all or reduced_path == simplify_xpath(case['start']) or reduced_path == simplify_xpath(case['end']):
-                        out.append('The time between ``{0}`` and ``{1}`` must not be over a year'.format(case['start'], case['end']))
-
-                elif rule == 'date_now':
-                    if show_all or reduced_path == simplify_xpath(case['date']):
-                        out.append('``{0}`` must not be more recent than the current date'.format(case['date']))
-
-                elif rule == 'if_then':
-                    if_case = extract_from_expr(case['if'])
-                    if show_all or (if_case.startswith(reduced_path) or if_case.endswith(reduced_path)):
-                        out.append('If ``{0}`` evaluates to true, then ``{1}`` must evaluate to true.'.format(case['if'], case['then']))
-
-                elif rule == 'one_or_all':
-                    if show_all or reduced_path == simplify_xpath(case['one']):
-                        out.append('``{0}`` must exist, otherwise all ``{1}`` must exist.'.format(case['one'], case['all']))
-
-                elif rule == 'evaluates_to_true':
-                    eval_case = extract_from_expr(case['eval'])
-                    if show_all or (eval_case.startswith(reduced_path) or eval_case.endswith(reduced_path)):
-                        out.append('``{0}`` must resolve to true.'.format(case['eval']))
-
-                elif rule == 'between_dates':
-                    if show_all or reduced_path == simplify_xpath(case['date']):
-                        out.append('The ``{0}`` must be between the ``{1}`` and ``{2}`` dates.'.format(case['date'], case['start'], case['end']))
-
-                elif rule == 'loop':
-                    continue
-                #   commenting this out and skipping until the way we render this is fixed
-                #   out.append('All elements in ``{0}`` are evaluated under the rules inside ``{1}``.'.format(case['foreach'],case['do']))
+            if 'ruleInfo' in case:
+                if reduced_path:
+                    if 'paths' in case:
+                        for case_path in case['paths']:
+                            if simplify_xpath(case_path) == reduced_path:
+                                out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
+                    included_path_keys = [path_key for path_key in possible_path_keys if path_key in case.keys()]
+                    for included_path_key in included_path_keys:
+                        case_path = case[included_path_key]
+                        if simplify_xpath(case_path) == reduced_path:
+                            out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
                 else:
-                    print('Not implemented', rule, reduced_path)
-    return out
+                    out.append((case['ruleInfo']['id'], case['ruleInfo']['message'], rule_link(case['ruleInfo']['id'])))
+            else:
+                sub_rules = case['do'].keys()
+                for sub_rule in sub_rules:
+                    sub_cases = case['do'][sub_rule]['cases']
+                    for sub_case in sub_cases:
+                        if reduced_path:
+                            if 'paths' in sub_case:
+                                for sub_case_path in sub_case['paths']:
+                                    if simplify_xpath(sub_case_path) == reduced_path:
+                                        out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
+                            included_path_keys = [path_key for path_key in possible_path_keys if path_key in sub_case.keys()]
+                            for included_path_key in included_path_keys:
+                                case_path = sub_case[included_path_key]
+                                if simplify_xpath(case_path) == reduced_path:
+                                    out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
+                        else:
+                            out.append((sub_case['ruleInfo']['id'], sub_case['ruleInfo']['message'], rule_link(sub_case['ruleInfo']['id'])))
+    unique_rules = [tup for tup in (set(tuple(i) for i in out))]
+    unique_rules.sort(key=lambda x: list(map(int, x[0].split('.'))))
+    return unique_rules

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -8,7 +8,10 @@
             "id": "1.1.3",
             "severity": "error",
             "category": "identifiers",
-            "message": "The activity identifier must be different to the organisation identifier of the reporting organisation."
+            "message": "The activity identifier must be different to the organisation identifier of the reporting organisation.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/iati-identifier/"
+            }
           }
         }
       ]
@@ -23,7 +26,10 @@
             "id": "1.1.21",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The activity identifier should begin with your IATI organisation identifier (either the current IATI Organisation identifier for the reporting organisation or a previous version included in other-identifier element) followed by a unique string for the activity separated by a hyphen"
+            "message": "The activity identifier should begin with your IATI organisation identifier (either the current IATI Organisation identifier for the reporting organisation or a previous version included in other-identifier element) followed by a unique string for the activity separated by a hyphen",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/iati-identifier/"
+            }
           }
         },
         {
@@ -34,7 +40,10 @@
             "id": "1.14.8",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting organisation id must start with an approved agency code."
+            "message": "The reporting organisation id must start with an approved agency code.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -47,7 +56,10 @@
             "id": "6.11.1",
             "severity": "error",
             "category": "information",
-            "message": "The activity must have a planned start date or an actual start date."
+            "message": "The activity must have a planned start date or an actual start date.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -56,7 +68,10 @@
             "id": "6.2.2",
             "severity": "error",
             "category": "classifications",
-            "message": "Each activity must have a specified sector, either at activity level OR for all transactions."
+            "message": "Each activity must have a specified sector, either at activity level OR for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         }
       ]
@@ -70,7 +85,8 @@
             "id": "4.1.1",
             "severity": "error",
             "category": "information",
-            "message": "The activity should specify a default language OR the language must be specified for each narrative element."
+            "message": "The activity should specify a default language OR the language must be specified for each narrative element.",
+            "link": { "path": "codelists/Language/" }
           }
         },
         {
@@ -80,7 +96,10 @@
             "id": "6.7.2",
             "severity": "error",
             "category": "classifications",
-            "message": "If sector is declared at transaction level, a sector must be declared for all transactions."
+            "message": "If sector is declared at transaction level, a sector must be declared for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -90,7 +109,8 @@
             "id": "7.8.1",
             "severity": "error",
             "category": "financial",
-            "message": "The activity should specify a default currency OR the currency must be specified for each monetary value."
+            "message": "The activity should specify a default currency OR the currency must be specified for each monetary value.",
+            "link": { "path": "codelists/Currency/" }
           }
         }
       ]
@@ -103,7 +123,10 @@
             "id": "11.1.1",
             "severity": "error",
             "category": "information",
-            "message": "The last updated datetime of the activity must not be in the future."
+            "message": "The last updated datetime of the activity must not be in the future.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/"
+            }
           }
         }
       ]
@@ -117,7 +140,10 @@
             "id": "11.1.2",
             "severity": "error",
             "category": "iati",
-            "message": "The planned start date of the activity must be before the planned end date."
+            "message": "The planned start date of the activity must be before the planned end date.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -127,7 +153,10 @@
             "id": "11.1.3",
             "severity": "error",
             "category": "iati",
-            "message": "The actual start date of the activity must be before the actual end date."
+            "message": "The actual start date of the activity must be before the actual end date.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -137,7 +166,10 @@
             "id": "11.1.4",
             "severity": "error",
             "category": "iati",
-            "message": "The actual start date of the activity must not be in the future."
+            "message": "The actual start date of the activity must not be in the future.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -147,7 +179,10 @@
             "id": "11.1.5",
             "severity": "error",
             "category": "iati",
-            "message": "The actual end date of the activity must not be in the future."
+            "message": "The actual end date of the activity must not be in the future.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-dates-status/"
+            }
           }
         },
         {
@@ -157,7 +192,10 @@
             "id": "11.2.1",
             "severity": "error",
             "category": "financial",
-            "message": "The transaction date must not be in the future."
+            "message": "The transaction date must not be in the future.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/financial-transactions/"
+            }
           }
         },
         {
@@ -167,7 +205,10 @@
             "id": "11.2.2",
             "severity": "error",
             "category": "financial",
-            "message": "The transaction value date must not be in the future."
+            "message": "The transaction value date must not be in the future.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/financial-transactions/"
+            }
           }
         }
       ]
@@ -193,7 +234,10 @@
             "id": "1.14.13",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?."
+            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -215,7 +259,10 @@
             "id": "1.14.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org identifier should not start or end with spaces or newlines."
+            "message": "The reporting-org identifier should not start or end with spaces or newlines.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         },
         {
@@ -262,7 +309,10 @@
                     "id": "4.4.1",
                     "severity": "error",
                     "category": "information",
-                    "message": "The description must contain narrative content."
+                    "message": "The description must contain narrative content.",
+                    "link": {
+                      "path": "activity-standard/iati-activities/iati-activity/title/"
+                    }
                   }
                 }
               ]
@@ -282,7 +332,10 @@
                     "id": "2.1.2",
                     "severity": "error",
                     "category": "classifications",
-                    "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%."
+                    "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+                    }
                   }
                 }
               ]
@@ -303,7 +356,10 @@
                     "id": "3.4.1",
                     "severity": "error",
                     "category": "geo",
-                    "message": "When multiple recipient countries or regions are declared, each must have a percentage."
+                    "message": "When multiple recipient countries or regions are declared, each must have a percentage.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+                    }
                   }
                 }
               ]
@@ -327,7 +383,10 @@
                     "id": "3.4.4",
                     "severity": "error",
                     "category": "geo",
-                    "message": "When a single recipient region in a vocabulary is declared, the percentage must either be omitted, or set to 100."
+                    "message": "When a single recipient region in a vocabulary is declared, the percentage must either be omitted, or set to 100.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+                    }
                   }
                 }
               ]
@@ -351,7 +410,10 @@
                     "id": "3.4.2",
                     "severity": "error",
                     "category": "geo",
-                    "message": "Percentage values for recipient countries or regions, must add up to 100%."
+                    "message": "Percentage values for recipient countries or regions, must add up to 100%.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+                    }
                   }
                 }
               ]
@@ -372,7 +434,10 @@
                     "id": "2.1.1",
                     "severity": "error",
                     "category": "classifications",
-                    "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
+                    "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+                    }
                   }
                 }
               ]
@@ -393,7 +458,10 @@
                     "id": "2.1.4",
                     "severity": "error",
                     "category": "classifications",
-                    "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
+                    "message": "When a single sector is declared, the percentage must either be omitted, or set to 100.",
+                    "link": {
+                      "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+                    }
                   }
                 }
               ]
@@ -415,7 +483,10 @@
             "id": "2.1.2",
             "severity": "error",
             "category": "classifications",
-            "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%."
+            "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -426,7 +497,10 @@
             "id": "3.1.2",
             "severity": "error",
             "category": "geo",
-            "message": "Percentage values for recipient countries, must add up to 100%."
+            "message": "Percentage values for recipient countries, must add up to 100%.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         }
       ]
@@ -435,52 +509,67 @@
       "cases": [
         {
           "paths": ["recipient-country/@percentage"],
-          "min": 0.0,
+          "min": 0,
           "ruleInfo": {
             "id": "12.1.2",
             "severity": "error",
             "category": "geo",
-            "message": "The country percentage value must be 0.0 or positive."
+            "message": "The country percentage value must be 0.0 or positive.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
           "paths": ["recipient-region/@percentage"],
-          "min": 0.0,
+          "min": 0,
           "ruleInfo": {
             "id": "12.1.2",
             "severity": "error",
             "category": "geo",
-            "message": "The region percentage value must be 0.0 or positive."
+            "message": "The region percentage value must be 0.0 or positive.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
           "paths": ["sector/@percentage"],
-          "min": 0.0,
+          "min": 0,
           "ruleInfo": {
             "id": "12.3.2",
             "severity": "error",
             "category": "classifications",
-            "message": "The sector percentage value must be 0.0 or positive."
+            "message": "The sector percentage value must be 0.0 or positive.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
           "paths": ["capital-spend/@percentage"],
-          "min": 0.0,
+          "min": 0,
           "ruleInfo": {
             "id": "12.2.2",
             "severity": "error",
             "category": "financial",
-            "message": "The percentage value must be 0.0 or positive."
+            "message": "The percentage value must be 0.0 or positive.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/capital-spend/"
+            }
           }
         },
         {
           "paths": ["country-budget-items/budget-item/@percentage"],
-          "min": 0.0,
+          "min": 0,
           "ruleInfo": {
             "id": "12.2.2",
             "severity": "error",
             "category": "financial",
-            "message": "The percentage value must be 0.0 or positive."
+            "message": "The percentage value must be 0.0 or positive.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/capital-spend/"
+            }
           }
         }
       ]
@@ -495,7 +584,10 @@
             "id": "4.3.1",
             "severity": "error",
             "category": "information",
-            "message": "The title must contain narrative content."
+            "message": "The title must contain narrative content.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/title/"
+            }
           }
         },
         {
@@ -506,7 +598,10 @@
             "id": "4.4.1",
             "severity": "error",
             "category": "information",
-            "message": "The description must contain narrative content."
+            "message": "The description must contain narrative content.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/title/"
+            }
           }
         },
         {
@@ -520,7 +615,10 @@
             "id": "2.2.1",
             "severity": "error",
             "category": "classifications",
-            "message": "When using a reporting organisation sector code (vocabulary 98 or 99), it must include a narrative."
+            "message": "When using a reporting organisation sector code (vocabulary 98 or 99), it must include a narrative.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -535,7 +633,10 @@
             "id": "102.1.1",
             "severity": "warning",
             "category": "information",
-            "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used."
+            "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -548,7 +649,10 @@
             "id": "2.1.1",
             "severity": "error",
             "category": "classifications",
-            "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
+            "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -561,7 +665,10 @@
             "id": "2.1.4",
             "severity": "error",
             "category": "classifications",
-            "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
+            "message": "When a single sector is declared, the percentage must either be omitted, or set to 100.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -572,7 +679,10 @@
             "id": "6.6.2",
             "severity": "error",
             "category": "classifications",
-            "message": "Sectors must only be declared at activity level OR for all transactions."
+            "message": "Sectors must only be declared at activity level OR for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-thematic-focus/"
+            }
           }
         },
         {
@@ -588,7 +698,10 @@
             "id": "3.6.2",
             "severity": "error",
             "category": "financial",
-            "message": "Recipient countries or regions must only be declared at activity level OR for all transactions."
+            "message": "Recipient countries or regions must only be declared at activity level OR for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/financial-transactions/"
+            }
           }
         },
         {
@@ -603,7 +716,10 @@
             "id": "3.7.1",
             "severity": "error",
             "category": "financial",
-            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
+            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
@@ -618,7 +734,10 @@
             "id": "3.7.2",
             "severity": "error",
             "category": "financial",
-            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
+            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
@@ -629,7 +748,10 @@
             "id": "3.1.1",
             "severity": "error",
             "category": "geo",
-            "message": "When multiple recipient countries are declared, each must have a percentage."
+            "message": "When multiple recipient countries are declared, each must have a percentage.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         },
         {
@@ -640,7 +762,10 @@
             "id": "3.1.4",
             "severity": "error",
             "category": "geo",
-            "message": "When a single recipient country is declared, the percentage must either be omitted, or set to 100."
+            "message": "When a single recipient country is declared, the percentage must either be omitted, or set to 100.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/countries-regions/"
+            }
           }
         }
       ]
@@ -803,7 +928,10 @@
             "id": "6.14.1",
             "severity": "error",
             "category": "classifications",
-            "message": "When using a policy marker code for vocabulary 1, it must include a significance."
+            "message": "When using a policy marker code for vocabulary 1, it must include a significance.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+            }
           }
         },
         {
@@ -813,7 +941,10 @@
             "id": "6.13.1",
             "severity": "error",
             "category": "classifications",
-            "message": "When using a reporting organisation policy marker code (vocabulary 99), it must include a narrative."
+            "message": "When using a reporting organisation policy marker code (vocabulary 99), it must include a narrative.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-classifications/"
+            }
           }
         }
       ]
@@ -830,7 +961,10 @@
             "id": "1.18.8",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting organisation id must start with an approved agency code."
+            "message": "The reporting organisation id must start with an approved agency code.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -845,7 +979,10 @@
             "id": "1.12.13",
             "severity": "warning",
             "category": "organisation",
-            "message": "The organisation-identifier must not contain any of the symbols /, &, | or ?."
+            "message": "The organisation-identifier must not contain any of the symbols /, &, | or ?.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         },
         {
@@ -856,7 +993,10 @@
             "id": "1.18.13",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?."
+            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -869,7 +1009,10 @@
             "id": "1.12.1",
             "severity": "warning",
             "category": "organisation",
-            "message": "The organisation-identifier should not start or end with spaces or newlines."
+            "message": "The organisation-identifier should not start or end with spaces or newlines.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         },
         {
@@ -887,7 +1030,10 @@
             "id": "1.18.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org identifier should not start or end with spaces or newlines."
+            "message": "The reporting-org identifier should not start or end with spaces or newlines.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/"
+            }
           }
         }
       ]
@@ -914,7 +1060,8 @@
             "id": "4.5.1",
             "severity": "error",
             "category": "information",
-            "message": "The organisation should specify a default language, or the language should be specified for each narrative element."
+            "message": "The organisation should specify a default language, or the language should be specified for each narrative element.",
+            "link": { "path": "codelists/Language/" }
           }
         },
         {
@@ -924,7 +1071,8 @@
             "id": "7.8.2",
             "severity": "error",
             "category": "financial",
-            "message": "The financial value must have a specified currency, or the organisation must declare a default currency."
+            "message": "The financial value must have a specified currency, or the organisation must declare a default currency.",
+            "link": { "path": "codelists/Currency/" }
           }
         }
       ]
@@ -939,7 +1087,10 @@
             "id": "6.10.1",
             "severity": "error",
             "category": "participating",
-            "message": "The participating organisation must have an identifier or a narrative."
+            "message": "The participating organisation must have an identifier or a narrative.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-participants/"
+            }
           }
         }
       ]
@@ -992,7 +1143,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1008,7 +1162,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1022,7 +1179,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1038,7 +1198,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1052,7 +1215,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1068,7 +1234,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1083,7 +1252,10 @@
             "id": "11.3.1",
             "severity": "error",
             "category": "financial",
-            "message": "The budget line value date must be within the budget period."
+            "message": "The budget line value date must be within the budget period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1097,7 +1269,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1113,7 +1288,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1127,7 +1305,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1143,7 +1324,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]
@@ -1157,7 +1341,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1172,7 +1359,10 @@
             "id": "8.11.1",
             "severity": "error",
             "category": "performance",
-            "message": "A reference code must only be declared at result OR result indicator level."
+            "message": "A reference code must only be declared at result OR result indicator level.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/reference/"
+            }
           }
         }
       ]
@@ -1188,7 +1378,10 @@
             "id": "8.6.1",
             "severity": "error",
             "category": "performance",
-            "message": "The start date of the indicator period must be before the end date of the indicator period."
+            "message": "The start date of the indicator period must be before the end date of the indicator period.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/result/indicator/period/period-start/"
+            }
           }
         }
       ]
@@ -1204,7 +1397,10 @@
             "id": "7.5.3",
             "severity": "error",
             "category": "financial",
-            "message": "Budget Period must not be longer than one year."
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
           }
         }
       ]
@@ -1218,7 +1414,10 @@
             "id": "8.6.3",
             "severity": "error",
             "category": "financial",
-            "message": "The start of the period must be before the end of the period."
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -192,7 +192,7 @@
             "id": "1.14.13",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -214,7 +214,7 @@
             "id": "1.14.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The reporting-org idenitifier should not start or end with spaces or newlines."
+            "message": "The reporting-org identifier should not start or end with spaces or newlines."
           }
         },
         {
@@ -667,7 +667,7 @@
             "id": "1.11.1",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The owner organisation idenitifier should not start or end with spaces or newlines."
+            "message": "The owner organisation identifier should not start or end with spaces or newlines."
           }
         }
       ]
@@ -682,7 +682,7 @@
             "id": "1.11.13",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The owner organisation idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The owner organisation identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -712,7 +712,7 @@
             "id": "1.10.13",
             "severity": "warning",
             "category": "financial",
-            "message": "The provider organisation idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The provider organisation identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -725,7 +725,7 @@
             "id": "1.10.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The provider organisation idenitifier should not start or end with spaces or newlines."
+            "message": "The provider organisation identifier should not start or end with spaces or newlines."
           }
         },
         {
@@ -734,7 +734,7 @@
             "id": "1.4.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The provider-org activity idenitifier should not start or end with spaces or newlines."
+            "message": "The provider-org activity identifier should not start or end with spaces or newlines."
           }
         }
       ]
@@ -762,7 +762,7 @@
             "id": "1.15.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The receiver-org idenitifier should not start or end with spaces or newlines."
+            "message": "The receiver-org identifier should not start or end with spaces or newlines."
           }
         },
         {
@@ -771,7 +771,7 @@
             "id": "1.5.1",
             "severity": "warning",
             "category": "financial",
-            "message": "The receiver-org activity idenitifier should not start or end with spaces or newlines."
+            "message": "The receiver-org activity identifier should not start or end with spaces or newlines."
           }
         }
       ]
@@ -786,7 +786,7 @@
             "id": "1.15.13",
             "severity": "warning",
             "category": "financial",
-            "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The receiver-org identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -844,7 +844,7 @@
             "id": "1.12.13",
             "severity": "warning",
             "category": "organisation",
-            "message": "The organisation-idenitifer must not contain any of the symbols /, &, | or ?."
+            "message": "The organisation-identifier must not contain any of the symbols /, &, | or ?."
           }
         },
         {
@@ -953,7 +953,7 @@
             "id": "1.8.13",
             "severity": "warning",
             "category": "participating",
-            "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
+            "message": "The receiver-org identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -780,7 +780,10 @@
             "id": "6.8.1",
             "severity": "error",
             "category": "information",
-            "message": "The owner organisation must have an identifier or a narrative."
+            "message": "The owner organisation must have an identifier or a narrative.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/other-identifier/owner-org/narrative"
+            }
           }
         }
       ]
@@ -823,7 +826,10 @@
             "id": "6.9.1",
             "severity": "error",
             "category": "financial",
-            "message": "The provider organisation must have an organisation identifier or a narrative."
+            "message": "The provider organisation must have an organisation identifier or a narrative.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/transaction/provider-org/narrative/"
+            }
           }
         }
       ]
@@ -875,7 +881,10 @@
             "id": "6.9.2",
             "severity": "error",
             "category": "financial",
-            "message": "The receiver organisation must have an organisation identifier or a narrative."
+            "message": "The receiver organisation must have an organisation identifier or a narrative.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/transaction/receiver-org/narrative/"
+            }
           }
         }
       ]
@@ -1046,7 +1055,10 @@
             "id": "11.4.1",
             "severity": "error",
             "category": "information",
-            "message": "The last updated datetime of the organisation must not be in the future."
+            "message": "The last updated datetime of the organisation must not be in the future.",
+            "link": {
+              "path": "organisation-standard/iati-organisations/iati-organisation/"
+            }
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1,82 +1,416 @@
 {
   "//iati-activity": {
+    "unique": {
+      "cases": [
+        {
+          "paths": ["reporting-org/@ref", "iati-identifier"],
+          "ruleInfo": {
+            "id": "1.1.3",
+            "severity": "error",
+            "category": "identifiers",
+            "message": "The activity identifier must be different to the organisation identifier of the reporting organisation."
+          }
+        }
+      ]
+    },
+    "startswith": {
+      "cases": [
+        {
+          "prefix": ["reporting-org/@ref", "other-identifier[@type='B1']/@ref"],
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.1.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The activity identifier should begin with the organisation identifier of the reporting organisation (or a previous version included in the other-identifier element)."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.3.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The iati-identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["planned-disbursement/provider-org/@ref"],
+          "ruleInfo": {
+            "id": "1.10.8",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["other-identifier/owner-org/@ref"],
+          "ruleInfo": {
+            "id": "1.11.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The owner organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.14.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["planned-disbursement/receiver-org/@ref"],
+          "ruleInfo": {
+            "id": "1.15.8",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiving organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["other-identifier[@type='B1']/@ref"],
+          "ruleInfo": {
+            "id": "1.16.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous reporting organisation identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["other-identifier[@type='A3']/@ref"],
+          "ruleInfo": {
+            "id": "1.6.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous activity identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": [
+            "planned-disbursement/provider-org/@provider-activity-id",
+            "transaction/provider-org/@provider-activity-id"
+          ],
+          "ruleInfo": {
+            "id": "1.4.8",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider activity identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": [
+            "planned-disbursement/receiver-org/@receiver-activity-id",
+            "/transaction/receiver-org/@receiver-activity-id"
+          ],
+          "ruleInfo": {
+            "id": "1.5.8",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver activity identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["related-activity/@ref"],
+          "ruleInfo": {
+            "id": "1.7.8",
+            "severity": "warning",
+            "category": "relations",
+            "message": "The related activity identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["participating-org/@ref"],
+          "ruleInfo": {
+            "id": "1.8.8",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating organisation identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["participating-org/@activity-id"],
+          "ruleInfo": {
+            "id": "1.9.8",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating organisation activity identifier must start with an approved agency code."
+          }
+        }
+      ]
+    },
     "atleast_one": {
       "cases": [
-        { "paths": ["activity-date[@type='1' or @type='2']"] },
-        { "paths": ["sector", "transaction/sector"] }
+        {
+          "paths": ["activity-date[@type='1' or @type='2']"],
+          "ruleInfo": {
+            "id": "6.11.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The activity must have a planned start date or an actual start date."
+          }
+        },
+        {
+          "paths": ["sector", "transaction/sector"],
+          "ruleInfo": {
+            "id": "6.2.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "Each activity must have a specified sector, either at activity level OR for all transactions."
+          }
+        }
       ]
     },
     "one_or_all": {
       "cases": [
-        { "one": "@xml:lang", "all": "lang" },
-        { "one": "sector", "all": "sector" },
-        { "one": "@default-currency", "all": "currency" }
-      ]
-    },
-    "only_one_of": {
-      "cases": [
         {
-          "excluded": ["recipient-region", "recipient-country"],
-          "paths": [
-            "transaction/recipient-country",
-            "transaction/recipient-region"
-          ]
+          "one": "@xml:lang",
+          "all": "lang",
+          "ruleInfo": {
+            "id": "4.1.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The activity should specify a default language OR the language must be specified for each narrative element."
+          }
+        },
+        {
+          "one": "sector",
+          "all": "sector",
+          "ruleInfo": {
+            "id": "6.7.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "If sector is declared at transaction level, a sector must be declared for all transactions."
+          }
+        },
+        {
+          "one": "@default-currency",
+          "all": "currency",
+          "ruleInfo": {
+            "id": "7.8.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The activity should specify a default currency OR the currency must be specified for each monetary value."
+          }
         }
       ]
     },
     "date_now": {
-      "cases": [{ "date": "@last-updated-datetime" }]
+      "cases": [
+        {
+          "date": "@last-updated-datetime",
+          "ruleInfo": {
+            "id": "11.1.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The last updated datetime of the activity must not be in the future."
+          }
+        }
+      ]
     },
     "date_order": {
       "cases": [
         {
           "less": "activity-date[@type='1']/@iso-date",
-          "more": "activity-date[@type='3']/@iso-date"
+          "more": "activity-date[@type='3']/@iso-date",
+          "ruleInfo": {
+            "id": "11.1.2",
+            "severity": "error",
+            "category": "iati",
+            "message": "The planned start date of the activity must be before the planned end date."
+          }
         },
         {
           "less": "activity-date[@type='2']/@iso-date",
-          "more": "activity-date[@type='4']/@iso-date"
+          "more": "activity-date[@type='4']/@iso-date",
+          "ruleInfo": {
+            "id": "11.1.3",
+            "severity": "error",
+            "category": "iati",
+            "message": "The actual start date of the activity must be before the actual end date."
+          }
         },
-        { "less": "activity-date[@type='2']/@iso-date", "more": "NOW" },
-        { "less": "activity-date[@type='4']/@iso-date", "more": "NOW" }
-      ]
-    },
-    "time_limit": {
-      "cases": [
         {
-          "start": "budget/period-start/@iso-date",
-          "end": "budget/period-end/@iso-date"
+          "less": "activity-date[@type='2']/@iso-date",
+          "more": "NOW",
+          "ruleInfo": {
+            "id": "11.1.4",
+            "severity": "error",
+            "category": "iati",
+            "message": "The actual start date of the activity must not be in the future."
+          }
+        },
+        {
+          "less": "activity-date[@type='4']/@iso-date",
+          "more": "NOW",
+          "ruleInfo": {
+            "id": "11.1.5",
+            "severity": "error",
+            "category": "iati",
+            "message": "The actual end date of the activity must not be in the future."
+          }
+        },
+        {
+          "less": "transaction/transaction-date/@iso-date",
+          "more": "NOW",
+          "ruleInfo": {
+            "id": "11.2.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The transaction date must not be in the future."
+          }
+        },
+        {
+          "less": "transaction/value/@value-date",
+          "more": "NOW",
+          "ruleInfo": {
+            "id": "11.2.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "The transaction value date must not be in the future."
+          }
         }
       ]
     },
-
     "regex_matches": {
       "cases": [
         {
-          "regex": "[^\\/\\&\\|\\?]+",
-          "paths": [
-            "reporting-org/@ref",
-            "iati-identifier",
-            "participating-org/@ref",
-            "transaction/provider-org/@ref",
-            "transaction/receiver-org/@ref"
-          ]
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.3.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The iati-identifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.14.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting-org idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["other-identifier[@type='B1']/@ref"],
+          "ruleInfo": {
+            "id": "1.16.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous reporting organisation identifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["other-identifier[@type='A3']/@ref"],
+          "ruleInfo": {
+            "id": "1.6.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous activity identifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["related-activity/@ref"],
+          "ruleInfo": {
+            "id": "1.7.13",
+            "severity": "warning",
+            "category": "relations",
+            "message": "The related activity identifier must not contain any of the symbols /, &, | or ?."
+          }
         }
       ]
     },
-    "sum": {
+    "no_spaces": {
       "cases": [
         {
-          "paths": [
-            "recipient-country/@percentage",
-            "recipient-region/@percentage"
-          ],
-          "sum": 100
+          "paths": ["iati-identifier"],
+          "ruleInfo": {
+            "id": "1.3.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The iati-identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.14.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting-org idenitifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["other-identifier[@type='B1']/@ref"],
+          "ruleInfo": {
+            "id": "1.16.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous reporting organisation identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["other-identifier[@type='A3']/@ref"],
+          "ruleInfo": {
+            "id": "1.6.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The previous activity identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["related-activity/@ref"],
+          "ruleInfo": {
+            "id": "1.7.1",
+            "severity": "warning",
+            "category": "relations",
+            "message": "The related activity identifier should not start or end with spaces or newlines."
+          }
         }
       ]
     },
     "loop": {
       "cases": [
+        {
+          "foreach": "description/@type",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "description[@type = '$1']/narrative",
+                  "then": "string(description[@type = '$1']//narrative) != ''",
+                  "ruleInfo": {
+                    "id": "4.4.1",
+                    "severity": "error",
+                    "category": "information",
+                    "message": "The description must contain narrative content."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
+        },
         {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
           "do": {
@@ -84,30 +418,190 @@
               "cases": [
                 {
                   "paths": ["sector[@vocabulary = '$1']/@percentage"],
-                  "sum": 100
+                  "sum": 100,
+                  "ruleInfo": {
+                    "id": "2.1.2",
+                    "severity": "error",
+                    "category": "classifications",
+                    "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%."
+                  }
                 }
               ]
             }
           },
           "subs": ["paths"]
+        },
+        {
+          "foreach": "recipient-region/@vocabulary",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(recipient-region[@vocabulary = '$1']) > 1",
+                  "then": "count(recipient-region[@vocabulary = '$1']) = count(recipient-region[@vocabulary = '$1']/@percentage)",
+                  "ruleInfo": {
+                    "id": "3.4.1",
+                    "severity": "error",
+                    "category": "geo",
+                    "message": "Percentage values for recipient countries or regions, must add up to 100%."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
+        },
+        {
+          "foreach": "recipient-region/@vocabulary",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(recipient-region[@vocabulary = '$1']) = 1 and not(recipient-country)",
+                  "then": "not(recipient-region[@vocabulary = '$1']/@percentage) or recipient-region[@vocabulary = '$1']/@percentage = 100",
+                  "ruleInfo": {
+                    "id": "3.4.4",
+                    "severity": "error",
+                    "category": "geo",
+                    "message": "When a single recipient region in a vocabulary is declared, the percentage must either be omitted, or set to 100."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
+        },
+        {
+          "foreach": "recipient-region/@vocabulary",
+          "do": {
+            "strict_sum": {
+              "cases": [
+                {
+                  "condition": "count(recipient-region[@vocabulary = '$1']) > 1",
+                  "paths": [
+                    "recipient-region[@vocabulary = '$1']/@percentage",
+                    "recipient-country/@percentage"
+                  ],
+                  "sum": 100,
+                  "ruleInfo": {
+                    "id": "3.4.2",
+                    "severity": "error",
+                    "category": "geo",
+                    "message": "Percentage values for recipient countries or regions, must add up to 100%."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["paths", "condition"]
+        },
+        {
+          "foreach": "default-aid-type[@vocabulary != 1]/@vocabulary",
+          "do": {
+            "no_more_than_one": {
+              "cases": [
+                {
+                  "paths": ["default-aid-type[@vocabulary = '$1']"],
+                  "ruleInfo": {
+                    "id": "107.1.2",
+                    "severity": "warning",
+                    "category": "financial",
+                    "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["paths"]
+        },
+        {
+          "foreach": "transaction/aid-type[@vocabulary != 1]/@vocabulary",
+          "do": {
+            "no_more_than_one": {
+              "cases": [
+                {
+                  "paths": ["transaction/aid-type[@vocabulary = '$1']"],
+                  "ruleInfo": {
+                    "id": "107.2.2",
+                    "severity": "warning",
+                    "category": "financial",
+                    "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["paths"]
+        },
+        {
+          "foreach": "sector[@vocabulary != '1']/@vocabulary",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(sector[@vocabulary = '$1']) > 1",
+                  "then": [
+                    "count(sector[@vocabulary = '$1']) = count(sector[@vocabulary = '$1']/@percentage)"
+                  ],
+                  "ruleInfo": {
+                    "id": "2.1.1",
+                    "severity": "error",
+                    "category": "classifications",
+                    "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
+        },
+        {
+          "foreach": "sector[@vocabulary != '1']/@vocabulary",
+          "do": {
+            "if_then": {
+              "cases": [
+                {
+                  "if": "count(sector[@vocabulary = '$1']) = 1",
+                  "then": "not(sector[@vocabulary = '$1']/@percentage) or sector[@vocabulary = '$1']/@percentage = 100",
+                  "ruleInfo": {
+                    "id": "2.1.4",
+                    "severity": "",
+                    "category": "classifications",
+                    "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
+                  }
+                }
+              ]
+            }
+          },
+          "subs": ["if", "then"]
         }
       ]
     },
     "strict_sum": {
       "cases": [
         {
+          "condition": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage) > 1",
           "paths": [
-            "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage"
+            "sector[@vocabulary = '1' or @vocabulary = '' or not(@vocabulary)]/@percentage"
           ],
-          "sum": 100
-        }
-      ]
-    },
-    "if_then": {
-      "cases": [
+          "sum": 100,
+          "ruleInfo": {
+            "id": "2.1.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "Percentage values for sectors, within a vocabulary (e.g. 1 - OECD DAC), must add up to 100%."
+          }
+        },
         {
-          "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
-          "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])"
+          "condition": "count(recipient-country) > 1 and not(recipient-region)",
+          "paths": ["recipient-country/@percentage"],
+          "sum": 100,
+          "ruleInfo": {
+            "id": "3.1.2",
+            "severity": "error",
+            "category": "geo",
+            "message": "Percentage values for recipient countries, must add up to 100%."
+          }
         }
       ]
     },
@@ -164,99 +658,639 @@
           }
         }
       ]
+    },
+    "if_then": {
+      "cases": [
+        {
+          "if": "title/narrative",
+          "then": "string(title//narrative) != ''",
+          "ruleInfo": {
+            "id": "4.3.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The title must contain narrative content."
+          }
+        },
+        {
+          "if": "count(description[not(@type) or @type = '']/narrative) > 0",
+          "then": "string(description[not(@type) or @type = '']//narrative) != ''",
+          "ruleInfo": {
+            "id": "4.4.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The description must contain narrative content."
+          }
+        },
+        {
+          "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
+          "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])",
+          "ruleInfo": {
+            "id": "2.2.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When using a reporting organisation sector code (vocabulary 98 or 99), it must include a narrative."
+          }
+        },
+        {
+          "if": "count(sector[not(@vocabulary='')]) + count(sector[not(@vocabulary='1')]) > 0",
+          "then": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 0",
+          "ruleInfo": {
+            "id": "102.1.1",
+            "severity": "warning",
+            "category": "information",
+            "message": "When a non OECD DAC sector vocabulary is used, sector vocabulary 1 - OECD DAC should also be used."
+          }
+        },
+        {
+          "if": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 1",
+          "then": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) = count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage)",
+          "ruleInfo": {
+            "id": "2.1.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When multiple sectors, within a vocabulary (e.g. 1 - OECD DAC) are declared, each must have a percentage."
+          }
+        },
+        {
+          "if": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) = 1",
+          "then": "not(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage) or sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage = 100",
+          "ruleInfo": {
+            "id": "2.1.4",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
+          }
+        },
+        {
+          "if": "count(sector) > 0",
+          "then": "count(transaction/sector) < 1",
+          "ruleInfo": {
+            "id": "6.6.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "Sectors must only be declared at activity level OR for all transactions."
+          }
+        },
+        {
+          "if": "recipient-country or recipient-region",
+          "then": "not(transaction/recipient-country or transaction/recipient-region)",
+          "ruleInfo": {
+            "id": "3.6.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "Recipient countries or regions must only be declared at activity level OR for all transactions."
+          }
+        },
+        {
+          "if": "not(recipient-country or recipient-region)",
+          "then": "transaction[recipient-country or recipient-region]",
+          "ruleInfo": {
+            "id": "3.7.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
+          }
+        },
+        {
+          "if": "not(recipient-country or recipient-region)",
+          "then": "not(transaction[not(recipient-country or recipient-region)])",
+          "ruleInfo": {
+            "id": "3.7.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "Recipient country or recipient region should be declared for either the activity or for all transactions."
+          }
+        },
+        {
+          "if": "count(recipient-country) > 1 and not(recipient-region)",
+          "then": "count(recipient-country) = count(recipient-country/@percentage)",
+          "ruleInfo": {
+            "id": "3.1.1",
+            "severity": "error",
+            "category": "geo",
+            "message": "When multiple recipient countries are declared, each must have a percentage."
+          }
+        },
+        {
+          "if": "count(recipient-country) = 1 and not(recipient-region)",
+          "then": "not(recipient-country/@percentage) or recipient-country/@percentage = 100",
+          "ruleInfo": {
+            "id": "3.1.4",
+            "severity": "error",
+            "category": "geo",
+            "message": "When a single recipient country is declared, the percentage must either be omitted, or set to 100."
+          }
+        }
+      ]
     }
   },
   "//iati-activity/other-identifier/owner-org": {
     "atleast_one": {
-      "cases": [{ "paths": ["@ref", "narrative"] }]
+      "cases": [
+        {
+          "paths": ["@ref", "narrative"],
+          "ruleInfo": {
+            "id": "6.8.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The owner organisation must have an identifier or a narrative."
+          }
+        }
+      ]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.11.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The owner organisation idenitifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
+    },
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.11.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The owner organisation idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        }
+      ]
     }
   },
-  "//iati-activity/transaction/provider-org": {
+  "//provider-org": {
     "atleast_one": {
-      "cases": [{ "paths": ["@ref", "narrative"] }]
+      "cases": [
+        {
+          "paths": ["@ref", "narrative"],
+          "ruleInfo": {
+            "id": "6.9.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The provider organisation must have an organisation identifier or a narrative."
+          }
+        }
+      ]
+    },
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.10.13",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider organisation idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@provider-activity-id"],
+          "ruleInfo": {
+            "id": "1.4.13",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider-org activity idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        }
+      ]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.10.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider organisation idenitifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["@provider-activity-id"],
+          "ruleInfo": {
+            "id": "1.4.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The provider-org activity idenitifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
     }
   },
-  "//iati-activity/transaction/receiver-org": {
+  "//receiver-org": {
     "atleast_one": {
-      "cases": [{ "paths": ["@ref", "narrative"] }]
+      "cases": [
+        {
+          "paths": ["@ref", "narrative"],
+          "ruleInfo": {
+            "id": "6.9.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "The receiver organisation must have an organisation identifier or a narrative."
+          }
+        }
+      ]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.15.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver-org idenitifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["@receiver-activity-id"],
+          "ruleInfo": {
+            "id": "1.5.1",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver-org activity idenitifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
+    },
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.15.13",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@receiver-activity-id"],
+          "ruleInfo": {
+            "id": "1.5.13",
+            "severity": "warning",
+            "category": "financial",
+            "message": "The receiver-org activity idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        }
+      ]
     }
   },
   "//policy-marker": {
     "atleast_one": {
       "cases": [
         {
-          "condition": "@vocabulary='1' or not(@vocabulary)",
-          "paths": ["@significance"]
+          "condition": "@vocabulary='1' or @vocabulary = '' or not(@vocabulary)",
+          "paths": ["@significance"],
+          "ruleInfo": {
+            "id": "6.14.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When using a policy marker code for vocabulary 1, it must include a significance."
+          }
         },
         {
           "condition": "@vocabulary='99'",
-          "paths": ["narrative"]
+          "paths": ["narrative"],
+          "ruleInfo": {
+            "id": "6.13.1",
+            "severity": "error",
+            "category": "classifications",
+            "message": "When using a reporting organisation policy marker code (vocabulary 99), it must include a narrative."
+          }
         }
       ]
     }
   },
   "//iati-organisation": {
+    "startswith": {
+      "cases": [
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["organisation-identifier"],
+          "ruleInfo": {
+            "id": "1.12.8",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The organisation-identifier must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["recipient-org-budget/recipient-org/@ref"],
+          "ruleInfo": {
+            "id": "1.17.8",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The recipient organisation id must start with an approved agency code."
+          }
+        },
+        {
+          "prefix": "ORG-ID-PREFIX",
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.18.8",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting organisation id must start with an approved agency code."
+          }
+        }
+      ]
+    },
     "regex_matches": {
       "cases": [
         {
-          "regex": "[^\\/\\&\\|\\?]+",
-          "paths": ["reporting-org/@ref", "organisation-identifier"]
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["organisation-identifier"],
+          "ruleInfo": {
+            "id": "1.12.13",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The organisation-idenitifer must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["recipient-org-budget/recipient-org/@ref"],
+          "ruleInfo": {
+            "id": "1.17.13",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The recipient organisation identifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.18.13",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting-org identifier must not contain any of the symbols /, &, | or ?."
+          }
+        }
+      ]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["organisation-identifier"],
+          "ruleInfo": {
+            "id": "1.12.1",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The organisation-identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["recipient-org-budget/recipient-org/@ref"],
+          "ruleInfo": {
+            "id": "1.17.1",
+            "severity": "warning",
+            "category": "organisation",
+            "message": "The recipient organisation identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["reporting-org/@ref"],
+          "ruleInfo": {
+            "id": "1.18.1",
+            "severity": "warning",
+            "category": "identifiers",
+            "message": "The reporting-org identifier should not start or end with spaces or newlines."
+          }
         }
       ]
     },
     "date_now": {
-      "cases": [{ "date": "@last-updated-datetime" }]
+      "cases": [
+        {
+          "date": "@last-updated-datetime",
+          "ruleInfo": {
+            "id": "11.4.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The last updated datetime of the organisation must not be in the future."
+          }
+        }
+      ]
     },
     "one_or_all": {
       "cases": [
-        { "one": "@xml:lang", "all": "lang" },
-        { "one": "@default-currency", "all": "currency" }
+        {
+          "one": "@xml:lang",
+          "all": "lang",
+          "ruleInfo": {
+            "id": "4.5.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The organisation should specify a default language, or the language should be specified for each narrative element."
+          }
+        },
+        {
+          "one": "@default-currency",
+          "all": "currency",
+          "ruleInfo": {
+            "id": "7.8.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "The financial value must have a specified currency, or the organisation must declare a default currency."
+          }
+        }
       ]
     }
   },
   "//participating-org": {
     "atleast_one": {
-      "cases": [{ "paths": ["@ref", "narrative"] }]
-    }
-  },
-  "//transaction": {
-    "date_order": {
       "cases": [
-        { "less": "transaction-date/@iso-date", "more": "NOW" },
-        { "less": "value/@value-date", "more": "NOW" }
+        {
+          "paths": ["@ref", "narrative"],
+          "ruleInfo": {
+            "id": "6.10.1",
+            "severity": "error",
+            "category": "participating",
+            "message": "The participating organisation must have an identifier or a narrative."
+          }
+        }
+      ]
+    },
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.8.13",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
+          }
+        },
+        {
+          "regex": "^[^\\/\\&\\|\\?]+$",
+          "paths": ["@activity-id"],
+          "ruleInfo": {
+            "id": "1.9.13",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating-org activity identifier must not contain any of the symbols /, &, | or ?."
+          }
+        }
       ]
     }
+  },
+  "no_spaces": {
+    "cases": [
+      {
+        "paths": ["@ref"],
+        "ruleInfo": {
+          "id": "1.8.1",
+          "severity": "warning",
+          "category": "participating",
+          "message": "The participating-org identifier should not start or end with spaces or newlines."
+        }
+      },
+      {
+        "paths": ["@activity-id"],
+        "ruleInfo": {
+          "id": "1.9.1",
+          "severity": "warning",
+          "category": "participating",
+          "message": "The participating-org activity identifier should not start or end with spaces or newlines."
+        }
+      }
+    ]
   },
   "//planned-disbursement": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
       ]
     }
   },
   "//budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
+      ]
+    }
+  },
+  "//budget/value": {
+    "atleast_one": {
+      "cases": [
+        {
+          "paths": ["@value-date"],
+          "ruleInfo": {
+            "id": "7.5.2",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Value must include a Value Date."
+          }
+        }
       ]
     }
   },
   "//total-budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "time_limit": {
       "cases": [
-        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
       ]
     }
   },
   "//recipient-country-budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "between_dates": {
@@ -264,7 +1298,13 @@
         {
           "date": "budget-line/value/@value-date",
           "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date"
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "11.3.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The budget line value date must be within the budget period."
+          }
         }
       ]
     },
@@ -272,7 +1312,13 @@
       "cases": [
         {
           "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date"
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
         }
       ]
     }
@@ -280,24 +1326,90 @@
   "//recipient-org-budget": {
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     },
     "time_limit": {
       "cases": [
         {
           "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date"
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
         }
       ]
     }
   },
   "//recipient-region-budget": {
+    "date_order": {
+      "cases": [
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
+      ]
+    },
     "time_limit": {
       "cases": [
         {
           "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date"
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
+        }
+      ]
+    }
+  },
+  "//result/indicator": {
+    "no_more_than_one": {
+      "cases": [
+        {
+          "paths": ["reference[1]", "../reference[1]"],
+          "ruleInfo": {
+            "id": "8.11.1",
+            "severity": "error",
+            "category": "performance",
+            "message": "A reference code must only be declared at result OR result indicator level."
+          }
+        }
+      ]
+    }
+  },
+  "//result/indicator/period": {
+    "date_order": {
+      "cases": [
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.1",
+            "severity": "error",
+            "category": "performance",
+            "message": "The start date of the indicator period must be before the end date of the indicator period."
+          }
         }
       ]
     }
@@ -307,15 +1419,28 @@
       "cases": [
         {
           "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date"
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year."
+          }
         }
       ]
-    }
-  },
-  "//result/indicator/period": {
+    },
     "date_order": {
       "cases": [
-        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period."
+          }
+        }
       ]
     }
   }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -17,12 +17,13 @@
       "cases": [
         {
           "prefix": ["reporting-org/@ref", "other-identifier[@type='B1']/@ref"],
+          "separator": "-",
           "paths": ["iati-identifier"],
           "ruleInfo": {
-            "id": "1.1.1",
+            "id": "1.1.21",
             "severity": "warning",
             "category": "identifiers",
-            "message": "The activity identifier should begin with the organisation identifier of the reporting organisation (or a previous version included in the other-identifier element)."
+            "message": "The activity identifier should begin with your IATI organisation identifier (either the current IATI Organisation identifier for the reporting organisation or a previous version included in other-identifier element) followed by a unique string for the activity separated by a hyphen"
           }
         },
         {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1027,21 +1027,6 @@
       ]
     }
   },
-  "//budget/value": {
-    "atleast_one": {
-      "cases": [
-        {
-          "paths": ["@value-date"],
-          "ruleInfo": {
-            "id": "7.5.2",
-            "severity": "error",
-            "category": "financial",
-            "message": "Budget Value must include a Value Date."
-          }
-        }
-      ]
-    }
-  },
   "//total-budget": {
     "date_order": {
       "cases": [

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -145,7 +145,23 @@
         },
         {
           "paths": ["capital-spend/@percentage"],
-          "min": 0.0
+          "min": 0.0,
+          "ruleInfo": {
+            "id": "12.2.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
+        },
+        {
+          "paths": ["country-budget-items/budget-item/@percentage"],
+          "min": 0.0,
+          "ruleInfo": {
+            "id": "12.2.1",
+            "severity": "error",
+            "category": "financial",
+            "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
         }
       ]
     }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -297,30 +297,6 @@
     "loop": {
       "cases": [
         {
-          "foreach": "description/@type",
-          "do": {
-            "if_then": {
-              "cases": [
-                {
-                  "if": "description[@type = '$1']/narrative",
-                  "then": "string(description[@type = '$1']//narrative) != ''",
-                  "paths": ["description[@type = '$1']/narrative"],
-                  "ruleInfo": {
-                    "id": "4.4.1",
-                    "severity": "error",
-                    "category": "information",
-                    "message": "The description must contain narrative content.",
-                    "link": {
-                      "path": "activity-standard/iati-activities/iati-activity/title/"
-                    }
-                  }
-                }
-              ]
-            }
-          },
-          "subs": ["if", "then", "paths"]
-        },
-        {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
           "do": {
             "strict_sum": {
@@ -576,34 +552,6 @@
     },
     "if_then": {
       "cases": [
-        {
-          "if": "title/narrative",
-          "then": "string(title//narrative) != ''",
-          "paths": ["title/narrative"],
-          "ruleInfo": {
-            "id": "4.3.1",
-            "severity": "error",
-            "category": "information",
-            "message": "The title must contain narrative content.",
-            "link": {
-              "path": "activity-standard/iati-activities/iati-activity/title/"
-            }
-          }
-        },
-        {
-          "if": "count(description[not(@type) or @type = '']/narrative) > 0",
-          "then": "string(description[not(@type) or @type = '']//narrative) != ''",
-          "paths": ["description[not(@type) or @type = '']/narrative"],
-          "ruleInfo": {
-            "id": "4.4.1",
-            "severity": "error",
-            "category": "information",
-            "message": "The description must contain narrative content.",
-            "link": {
-              "path": "activity-standard/iati-activities/iati-activity/title/"
-            }
-          }
-        },
         {
           "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
           "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])",
@@ -1429,6 +1377,42 @@
             "message": "The start of the period must be before the end of the period.",
             "link": {
               "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "//title": {
+    "atleast_one": {
+      "cases": [
+        {
+          "paths": ["narrative/text()"],
+          "ruleInfo": {
+            "id": "4.3.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The title must contain narrative content.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/title/"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "//description": {
+    "atleast_one": {
+      "cases": [
+        {
+          "paths": ["narrative/text()"],
+          "ruleInfo": {
+            "id": "4.4.1",
+            "severity": "error",
+            "category": "information",
+            "message": "The description must contain narrative content.",
+            "link": {
+              "path": "activity-standard/iati-activities/iati-activity/description/"
             }
           }
         }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1,5 +1,5 @@
 {
-  "//iati-activity": {
+  "/iati-activities/iati-activity": {
     "unique": {
       "cases": [
         {
@@ -719,7 +719,7 @@
       ]
     }
   },
-  "//iati-activity/other-identifier/owner-org": {
+  "/iati-activities/iati-activity/other-identifier/owner-org": {
     "atleast_one": {
       "cases": [
         {
@@ -765,7 +765,7 @@
       ]
     }
   },
-  "//provider-org": {
+  "/iati-activities/iati-activity/transaction/provider-org | /iati-activities/iati-activity/planned-disbursement/provider-org": {
     "atleast_one": {
       "cases": [
         {
@@ -820,7 +820,7 @@
       ]
     }
   },
-  "//receiver-org": {
+  "/iati-activities/iati-activity/transaction/receiver-org | /iati-activities/iati-activity/planned-disbursement/receiver-org": {
     "atleast_one": {
       "cases": [
         {
@@ -875,7 +875,7 @@
       ]
     }
   },
-  "//policy-marker": {
+  "/iati-activities/iati-activity/policy-marker": {
     "atleast_one": {
       "cases": [
         {
@@ -907,7 +907,7 @@
       ]
     }
   },
-  "//iati-organisation": {
+  "/iati-organisations/iati-organisation": {
     "startswith": {
       "cases": [
         {
@@ -1038,7 +1038,7 @@
       ]
     }
   },
-  "//participating-org": {
+  "/iati-activities/iati-activity/participating-org": {
     "atleast_one": {
       "cases": [
         {
@@ -1093,7 +1093,7 @@
       ]
     }
   },
-  "//planned-disbursement": {
+  "/iati-activities/iati-activity/planned-disbursement": {
     "date_order": {
       "cases": [
         {
@@ -1112,43 +1112,7 @@
       ]
     }
   },
-  "//budget": {
-    "date_order": {
-      "cases": [
-        {
-          "less": "period-start/@iso-date",
-          "more": "period-end/@iso-date",
-          "ruleInfo": {
-            "id": "8.6.3",
-            "severity": "error",
-            "category": "financial",
-            "message": "The start of the period must be before the end of the period.",
-            "link": {
-              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
-            }
-          }
-        }
-      ]
-    },
-    "time_limit": {
-      "cases": [
-        {
-          "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date",
-          "ruleInfo": {
-            "id": "7.5.3",
-            "severity": "error",
-            "category": "financial",
-            "message": "Budget Period must not be longer than one year.",
-            "link": {
-              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
-            }
-          }
-        }
-      ]
-    }
-  },
-  "//total-budget": {
+  "/iati-activities/iati-activity/budget": {
     "date_order": {
       "cases": [
         {
@@ -1184,7 +1148,43 @@
       ]
     }
   },
-  "//recipient-country-budget": {
+  "/iati-organisations/iati-organisation/total-budget": {
+    "date_order": {
+      "cases": [
+        {
+          "less": "period-start/@iso-date",
+          "more": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "8.6.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "The start of the period must be before the end of the period.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/organisation-budgets-spend/"
+            }
+          }
+        }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date",
+          "ruleInfo": {
+            "id": "7.5.3",
+            "severity": "error",
+            "category": "financial",
+            "message": "Budget Period must not be longer than one year.",
+            "link": {
+              "url": "https://iatistandard.org/en/guidance/standard-guidance/activity-budgets/"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "/iati-organisations/iati-organisation/recipient-country-budget": {
     "date_order": {
       "cases": [
         {
@@ -1238,7 +1238,7 @@
       ]
     }
   },
-  "//recipient-org-budget": {
+  "/iati-organisations/iati-organisation/recipient-org-budget": {
     "date_order": {
       "cases": [
         {
@@ -1274,7 +1274,7 @@
       ]
     }
   },
-  "//recipient-region-budget": {
+  "/iati-organisations/iati-organisation/recipient-region-budget": {
     "date_order": {
       "cases": [
         {
@@ -1310,7 +1310,7 @@
       ]
     }
   },
-  "//result/indicator": {
+  "/iati-activities/iati-activity/result/indicator": {
     "no_more_than_one": {
       "cases": [
         {
@@ -1328,7 +1328,7 @@
       ]
     }
   },
-  "//result/indicator/period": {
+  "/iati-activities/iati-activity/result/indicator/period": {
     "date_order": {
       "cases": [
         {
@@ -1347,7 +1347,7 @@
       ]
     }
   },
-  "//total-expenditure": {
+  "/iati-organisations/iati-organisation/total-expenditure": {
     "time_limit": {
       "cases": [
         {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -115,11 +115,23 @@
       "cases": [
         {
           "paths": ["recipient-country/@percentage"],
-          "min": 0.0
+          "min": 0.0,
+          "ruleInfo": {
+            "id": "12.1.1",
+            "severity": "error",
+            "category": "geo",
+            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
         },
         {
           "paths": ["recipient-region/@percentage"],
-          "min": 0.0
+          "min": 0.0,
+          "ruleInfo": {
+            "id": "12.1.1",
+            "severity": "error",
+            "category": "geo",
+            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
+          }
         },
         {
           "paths": ["sector/@percentage"],

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -117,7 +117,7 @@
           "paths": ["recipient-country/@percentage"],
           "min": 0.0,
           "ruleInfo": {
-            "id": "12.1.1",
+            "id": "12.1.2",
             "severity": "error",
             "category": "geo",
             "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
@@ -127,7 +127,7 @@
           "paths": ["recipient-region/@percentage"],
           "min": 0.0,
           "ruleInfo": {
-            "id": "12.1.1",
+            "id": "12.1.2",
             "severity": "error",
             "category": "geo",
             "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
@@ -147,7 +147,7 @@
           "paths": ["capital-spend/@percentage"],
           "min": 0.0,
           "ruleInfo": {
-            "id": "12.2.1",
+            "id": "12.2.2",
             "severity": "error",
             "category": "financial",
             "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
@@ -157,7 +157,7 @@
           "paths": ["country-budget-items/budget-item/@percentage"],
           "min": 0.0,
           "ruleInfo": {
-            "id": "12.2.1",
+            "id": "12.2.2",
             "severity": "error",
             "category": "financial",
             "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -1,269 +1,294 @@
 {
-    "//iati-activity": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "activity-date[@type='1' or @type='2']" ] },
-                { "paths": [ "sector", "transaction/sector" ] }
-            ]
+  "//iati-activity": {
+    "atleast_one": {
+      "cases": [
+        { "paths": ["activity-date[@type='1' or @type='2']"] },
+        { "paths": ["sector", "transaction/sector"] }
+      ]
+    },
+    "one_or_all": {
+      "cases": [
+        { "one": "@xml:lang", "all": "lang" },
+        { "one": "sector", "all": "sector" },
+        { "one": "@default-currency", "all": "currency" }
+      ]
+    },
+    "only_one_of": {
+      "cases": [
+        {
+          "excluded": ["recipient-region", "recipient-country"],
+          "paths": [
+            "transaction/recipient-country",
+            "transaction/recipient-region"
+          ]
+        }
+      ]
+    },
+    "date_now": {
+      "cases": [{ "date": "@last-updated-datetime" }]
+    },
+    "date_order": {
+      "cases": [
+        {
+          "less": "activity-date[@type='1']/@iso-date",
+          "more": "activity-date[@type='3']/@iso-date"
         },
-        "one_or_all": {
-            "cases": [
-                { "one":"@xml:lang", "all":"lang" },
-                { "one":"sector", "all":"sector" },
-                { "one":"@default-currency", "all":"currency" }
-            ]
+        {
+          "less": "activity-date[@type='2']/@iso-date",
+          "more": "activity-date[@type='4']/@iso-date"
         },
-        "only_one_of": {
-            "cases": [
-                {
-                    "excluded": [ "recipient-region", "recipient-country" ],
-                    "paths": [ "transaction/recipient-country", "transaction/recipient-region" ]
-                }
-            ]
-        },
-        "date_now": {
-            "cases": [
-                { "date": "@last-updated-datetime" }
-            ]
-        },
-        "date_order": {
-            "cases": [
-                { "less": "activity-date[@type='1']/@iso-date", "more": "activity-date[@type='3']/@iso-date" },
-                { "less": "activity-date[@type='2']/@iso-date", "more": "activity-date[@type='4']/@iso-date" },
-                { "less": "activity-date[@type='2']/@iso-date", "more": "NOW" },
-                { "less": "activity-date[@type='4']/@iso-date", "more": "NOW" }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                { "start": "budget/period-start/@iso-date", "end": "budget/period-end/@iso-date" }
-            ]
-        },
+        { "less": "activity-date[@type='2']/@iso-date", "more": "NOW" },
+        { "less": "activity-date[@type='4']/@iso-date", "more": "NOW" }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        {
+          "start": "budget/period-start/@iso-date",
+          "end": "budget/period-end/@iso-date"
+        }
+      ]
+    },
 
-        "regex_matches": {
-            "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
-                  "paths": [ "reporting-org/@ref", "iati-identifier", "participating-org/@ref", "transaction/provider-org/@ref", "transaction/receiver-org/@ref" ] }
-            ]
-        },
-        "sum": {
-            "cases": [ {
-                "paths": [ "recipient-country/@percentage", "recipient-region/@percentage" ],
-                "sum": 100
-             } ]
-        },
-        "loop": {
-            "cases": [
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "[^\\/\\&\\|\\?]+",
+          "paths": [
+            "reporting-org/@ref",
+            "iati-identifier",
+            "participating-org/@ref",
+            "transaction/provider-org/@ref",
+            "transaction/receiver-org/@ref"
+          ]
+        }
+      ]
+    },
+    "sum": {
+      "cases": [
+        {
+          "paths": [
+            "recipient-country/@percentage",
+            "recipient-region/@percentage"
+          ],
+          "sum": 100
+        }
+      ]
+    },
+    "loop": {
+      "cases": [
+        {
+          "foreach": "sector[@vocabulary != '1']/@vocabulary",
+          "do": {
+            "strict_sum": {
+              "cases": [
                 {
-                    "foreach": "sector[@vocabulary != '1']/@vocabulary",
-                    "do": {
-                        "strict_sum": {
-                            "cases": [
-                                {
-                                    "paths": [ "sector[@vocabulary = '$1']/@percentage" ],
-                                    "sum": 100
-                                }
-                            ]
-                        }
-                    },
-                    "subs": ["paths"]
+                  "paths": ["sector[@vocabulary = '$1']/@percentage"],
+                  "sum": 100
                 }
-            ]
+              ]
+            }
+          },
+          "subs": ["paths"]
+        }
+      ]
+    },
+    "strict_sum": {
+      "cases": [
+        {
+          "paths": [
+            "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage"
+          ],
+          "sum": 100
+        }
+      ]
+    },
+    "if_then": {
+      "cases": [
+        {
+          "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
+          "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])"
+        }
+      ]
+    },
+    "range": {
+      "cases": [
+        {
+          "paths": ["recipient-country/@percentage"],
+          "min": 0.0
         },
-        "strict_sum": {
-            "cases": [
-                {
-                    "paths": [ "sector[@vocabulary = '1' or not(@vocabulary)]/@percentage" ],
-                    "sum": 100
-                }
-            ]
+        {
+          "paths": ["recipient-region/@percentage"],
+          "min": 0.0
         },
-        "if_then": {
-            "cases":[
-                {
-                    "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
-                    "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])"
-                }
-            ]
+        {
+          "paths": ["sector/@percentage"],
+          "min": 0.0,
+          "ruleInfo": {
+            "id": "12.3.2",
+            "severity": "error",
+            "category": "classifications",
+            "message": "The sector percentage value must be 0.0 or positive."
+          }
         },
-        "range": {
-            "cases": [
-                {
-                    "paths": ["recipient-country/@percentage"],
-                    "min": 0.0
-                },
-                {
-                    "paths": ["recipient-region/@percentage"],
-                    "min": 0.0
-                },
-                {
-                    "paths": ["sector/@percentage"],
-                    "min": 0.0
-                },
-                {
-                    "paths": ["capital-spend/@percentage"],
-                    "min": 0.0
-                }
-            ]
+        {
+          "paths": ["capital-spend/@percentage"],
+          "min": 0.0
         }
-    },
-    "//iati-activity/other-identifier/owner-org": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@ref", "narrative" ]}
-            ]
-        }
-    },
-    "//iati-activity/transaction/provider-org": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@ref", "narrative" ]}
-            ]
-        }
-    },
-    "//iati-activity/transaction/receiver-org": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@ref", "narrative" ]}
-            ]
-        }
-    },
-    "//policy-marker": {
-        "atleast_one": {
-            "cases": [
-                {
-                    "condition": "@vocabulary='1' or not(@vocabulary)",
-                    "paths": [ "@significance" ]
-                },
-                {
-                    "condition": "@vocabulary='99'",
-                    "paths": [ "narrative" ]
-                }
-            ]
-        }
-    },
-    "//iati-organisation": {
-        "regex_matches": {
-            "cases": [
-                { "regex": "[^\\/\\&\\|\\?]+",
-                  "paths": [ "reporting-org/@ref", "organisation-identifier" ] }
-            ]
-        },
-        "date_now": {
-            "cases": [
-                { "date": "@last-updated-datetime" }
-            ]
-        },
-        "one_or_all": {
-            "cases": [
-                { "one":"@xml:lang", "all":"lang" },
-                { "one":"@default-currency", "all":"currency" }
-            ]
-        }
-    },
-    "//participating-org": {
-        "atleast_one": {
-            "cases": [
-                { "paths": [ "@ref", "narrative" ] }
-            ]
-        }
-    },
-    "//transaction": {
-        "date_order": {
-            "cases": [
-                { "less": "transaction-date/@iso-date", "more": "NOW" },
-                { "less": "value/@value-date", "more": "NOW" }
-            ]
-        }
-    },
-    "//planned-disbursement": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        }
-    },
-    "//total-budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                { "start": "period-start/@iso-date", "end": "period-end/@iso-date"}
-            ]
-        }
-    },
-    "//recipient-country-budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        },
-        "between_dates": {
-            "cases": [
-                { 
-                    "date": "budget-line/value/@value-date", 
-                    "start": "period-start/@iso-date", 
-                    "end": "period-end/@iso-date"
-                }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                {
-                    "start": "period-start/@iso-date",
-                    "end": "period-end/@iso-date"
-                }
-            ]
-        }
-    },
-    "//recipient-org-budget": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        },
-        "time_limit": {
-            "cases": [
-                {
-                    "start": "period-start/@iso-date",
-                    "end": "period-end/@iso-date"
-                }
-            ]
-        }
-    },
-    "//recipient-region-budget": {
-        "time_limit": {
-            "cases": [
-                {
-                    "start": "period-start/@iso-date", "end": "period-end/@iso-date"
-                }
-            ]
-        }
-    },
-    "//total-expenditure": {
-        "time_limit": {
-            "cases": [
-                {
-                    "start": "period-start/@iso-date", "end": "period-end/@iso-date"
-                }
-            ]
-        }
-    },
-    "//result/indicator/period": {
-        "date_order": {
-            "cases": [
-                { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
-            ]
-        }
+      ]
     }
+  },
+  "//iati-activity/other-identifier/owner-org": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@ref", "narrative"] }]
+    }
+  },
+  "//iati-activity/transaction/provider-org": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@ref", "narrative"] }]
+    }
+  },
+  "//iati-activity/transaction/receiver-org": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@ref", "narrative"] }]
+    }
+  },
+  "//policy-marker": {
+    "atleast_one": {
+      "cases": [
+        {
+          "condition": "@vocabulary='1' or not(@vocabulary)",
+          "paths": ["@significance"]
+        },
+        {
+          "condition": "@vocabulary='99'",
+          "paths": ["narrative"]
+        }
+      ]
+    }
+  },
+  "//iati-organisation": {
+    "regex_matches": {
+      "cases": [
+        {
+          "regex": "[^\\/\\&\\|\\?]+",
+          "paths": ["reporting-org/@ref", "organisation-identifier"]
+        }
+      ]
+    },
+    "date_now": {
+      "cases": [{ "date": "@last-updated-datetime" }]
+    },
+    "one_or_all": {
+      "cases": [
+        { "one": "@xml:lang", "all": "lang" },
+        { "one": "@default-currency", "all": "currency" }
+      ]
+    }
+  },
+  "//participating-org": {
+    "atleast_one": {
+      "cases": [{ "paths": ["@ref", "narrative"] }]
+    }
+  },
+  "//transaction": {
+    "date_order": {
+      "cases": [
+        { "less": "transaction-date/@iso-date", "more": "NOW" },
+        { "less": "value/@value-date", "more": "NOW" }
+      ]
+    }
+  },
+  "//planned-disbursement": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//total-budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        { "start": "period-start/@iso-date", "end": "period-end/@iso-date" }
+      ]
+    }
+  },
+  "//recipient-country-budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    },
+    "between_dates": {
+      "cases": [
+        {
+          "date": "budget-line/value/@value-date",
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date"
+        }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date"
+        }
+      ]
+    }
+  },
+  "//recipient-org-budget": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    },
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date"
+        }
+      ]
+    }
+  },
+  "//recipient-region-budget": {
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date"
+        }
+      ]
+    }
+  },
+  "//total-expenditure": {
+    "time_limit": {
+      "cases": [
+        {
+          "start": "period-start/@iso-date",
+          "end": "period-end/@iso-date"
+        }
+      ]
+    }
+  },
+  "//result/indicator/period": {
+    "date_order": {
+      "cases": [
+        { "less": "period-start/@iso-date", "more": "period-end/@iso-date" }
+      ]
+    }
+  }
 }

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -27,7 +27,7 @@
         },
         {
           "idCondition": "NOT_EXISTING_ORG_ID",
-          "prefix": "ORG-ID-PREFIX",
+          "prefix": ["ORG-ID-PREFIX"],
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.14.8",
@@ -365,9 +365,7 @@
               "cases": [
                 {
                   "if": "count(sector[@vocabulary = '$1']) > 1",
-                  "then": [
-                    "count(sector[@vocabulary = '$1']) = count(sector[@vocabulary = '$1']/@percentage)"
-                  ],
+                  "then": "count(sector[@vocabulary = '$1']) = count(sector[@vocabulary = '$1']/@percentage)",
                   "paths": ["sector[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "2.1.1",
@@ -392,7 +390,7 @@
                   "paths": ["sector[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "2.1.4",
-                    "severity": "",
+                    "severity": "error",
                     "category": "classifications",
                     "message": "When a single sector is declared, the percentage must either be omitted, or set to 100."
                   }
@@ -825,7 +823,7 @@
       "cases": [
         {
           "idCondition": "NOT_EXISTING_ORG_ID",
-          "prefix": "ORG-ID-PREFIX",
+          "prefix": ["ORG-ID-PREFIX"],
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
             "id": "1.18.8",

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -959,29 +959,29 @@
           }
         }
       ]
+    },
+    "no_spaces": {
+      "cases": [
+        {
+          "paths": ["@ref"],
+          "ruleInfo": {
+            "id": "1.8.1",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating-org identifier should not start or end with spaces or newlines."
+          }
+        },
+        {
+          "paths": ["@activity-id"],
+          "ruleInfo": {
+            "id": "1.9.1",
+            "severity": "warning",
+            "category": "participating",
+            "message": "The participating-org activity identifier should not start or end with spaces or newlines."
+          }
+        }
+      ]
     }
-  },
-  "no_spaces": {
-    "cases": [
-      {
-        "paths": ["@ref"],
-        "ruleInfo": {
-          "id": "1.8.1",
-          "severity": "warning",
-          "category": "participating",
-          "message": "The participating-org identifier should not start or end with spaces or newlines."
-        }
-      },
-      {
-        "paths": ["@activity-id"],
-        "ruleInfo": {
-          "id": "1.9.1",
-          "severity": "warning",
-          "category": "participating",
-          "message": "The participating-org activity identifier should not start or end with spaces or newlines."
-        }
-      }
-    ]
   },
   "//planned-disbursement": {
     "date_order": {

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -26,36 +26,7 @@
           }
         },
         {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["iati-identifier"],
-          "ruleInfo": {
-            "id": "1.3.8",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The iati-identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["planned-disbursement/provider-org/@ref"],
-          "ruleInfo": {
-            "id": "1.10.8",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The provider organisation id must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["other-identifier/owner-org/@ref"],
-          "ruleInfo": {
-            "id": "1.11.8",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The owner organisation id must start with an approved agency code."
-          }
-        },
-        {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "prefix": "ORG-ID-PREFIX",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
@@ -63,92 +34,6 @@
             "severity": "warning",
             "category": "identifiers",
             "message": "The reporting organisation id must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["planned-disbursement/receiver-org/@ref"],
-          "ruleInfo": {
-            "id": "1.15.8",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The receiving organisation id must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["other-identifier[@type='B1']/@ref"],
-          "ruleInfo": {
-            "id": "1.16.8",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The previous reporting organisation identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["other-identifier[@type='A3']/@ref"],
-          "ruleInfo": {
-            "id": "1.6.8",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The previous activity identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": [
-            "planned-disbursement/provider-org/@provider-activity-id",
-            "transaction/provider-org/@provider-activity-id"
-          ],
-          "ruleInfo": {
-            "id": "1.4.8",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The provider activity identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": [
-            "planned-disbursement/receiver-org/@receiver-activity-id",
-            "/transaction/receiver-org/@receiver-activity-id"
-          ],
-          "ruleInfo": {
-            "id": "1.5.8",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The receiver activity identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["related-activity/@ref"],
-          "ruleInfo": {
-            "id": "1.7.8",
-            "severity": "warning",
-            "category": "relations",
-            "message": "The related activity identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["participating-org/@ref"],
-          "ruleInfo": {
-            "id": "1.8.8",
-            "severity": "warning",
-            "category": "participating",
-            "message": "The participating organisation identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["participating-org/@activity-id"],
-          "ruleInfo": {
-            "id": "1.9.8",
-            "severity": "warning",
-            "category": "participating",
-            "message": "The participating organisation activity identifier must start with an approved agency code."
           }
         }
       ]
@@ -289,6 +174,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID_PREFIX",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["iati-identifier"],
           "ruleInfo": {
@@ -299,6 +185,7 @@
           }
         },
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
@@ -306,36 +193,6 @@
             "severity": "warning",
             "category": "identifiers",
             "message": "The reporting-org idenitifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["other-identifier[@type='B1']/@ref"],
-          "ruleInfo": {
-            "id": "1.16.13",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The previous reporting organisation identifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["other-identifier[@type='A3']/@ref"],
-          "ruleInfo": {
-            "id": "1.6.13",
-            "severity": "warning",
-            "category": "identifiers",
-            "message": "The previous activity identifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["related-activity/@ref"],
-          "ruleInfo": {
-            "id": "1.7.13",
-            "severity": "warning",
-            "category": "relations",
-            "message": "The related activity identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -399,6 +256,7 @@
                 {
                   "if": "description[@type = '$1']/narrative",
                   "then": "string(description[@type = '$1']//narrative) != ''",
+                  "paths": ["description[@type = '$1']/narrative"],
                   "ruleInfo": {
                     "id": "4.4.1",
                     "severity": "error",
@@ -409,7 +267,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
@@ -439,17 +297,18 @@
                 {
                   "if": "count(recipient-region[@vocabulary = '$1']) > 1",
                   "then": "count(recipient-region[@vocabulary = '$1']) = count(recipient-region[@vocabulary = '$1']/@percentage)",
+                  "paths": ["recipient-region[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "3.4.1",
                     "severity": "error",
                     "category": "geo",
-                    "message": "Percentage values for recipient countries or regions, must add up to 100%."
+                    "message": "When multiple recipient countries or regions are declared, each must have a percentage."
                   }
                 }
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "recipient-region/@vocabulary",
@@ -459,6 +318,10 @@
                 {
                   "if": "count(recipient-region[@vocabulary = '$1']) = 1 and not(recipient-country)",
                   "then": "not(recipient-region[@vocabulary = '$1']/@percentage) or recipient-region[@vocabulary = '$1']/@percentage = 100",
+                  "paths": [
+                    "recipient-region[@vocabulary = '$1']",
+                    "recipient-country"
+                  ],
                   "ruleInfo": {
                     "id": "3.4.4",
                     "severity": "error",
@@ -469,7 +332,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "recipient-region/@vocabulary",
@@ -477,7 +340,7 @@
             "strict_sum": {
               "cases": [
                 {
-                  "condition": "count(recipient-region[@vocabulary = '$1']) > 1",
+                  "condition": "count(recipient-region[@vocabulary = '$1']) + count(recipient-country) > 1",
                   "paths": [
                     "recipient-region[@vocabulary = '$1']/@percentage",
                     "recipient-country/@percentage"
@@ -496,44 +359,6 @@
           "subs": ["paths", "condition"]
         },
         {
-          "foreach": "default-aid-type[@vocabulary != 1]/@vocabulary",
-          "do": {
-            "no_more_than_one": {
-              "cases": [
-                {
-                  "paths": ["default-aid-type[@vocabulary = '$1']"],
-                  "ruleInfo": {
-                    "id": "107.1.2",
-                    "severity": "warning",
-                    "category": "financial",
-                    "message": "Each activity should only contain one default aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
-                  }
-                }
-              ]
-            }
-          },
-          "subs": ["paths"]
-        },
-        {
-          "foreach": "transaction/aid-type[@vocabulary != 1]/@vocabulary",
-          "do": {
-            "no_more_than_one": {
-              "cases": [
-                {
-                  "paths": ["transaction/aid-type[@vocabulary = '$1']"],
-                  "ruleInfo": {
-                    "id": "107.2.2",
-                    "severity": "warning",
-                    "category": "financial",
-                    "message": "Each transaction should only contain one aid type code per aid type vocabulary (e.g. 1 - OECD DAC)"
-                  }
-                }
-              ]
-            }
-          },
-          "subs": ["paths"]
-        },
-        {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
           "do": {
             "if_then": {
@@ -543,6 +368,7 @@
                   "then": [
                     "count(sector[@vocabulary = '$1']) = count(sector[@vocabulary = '$1']/@percentage)"
                   ],
+                  "paths": ["sector[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "2.1.1",
                     "severity": "error",
@@ -553,7 +379,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         },
         {
           "foreach": "sector[@vocabulary != '1']/@vocabulary",
@@ -563,6 +389,7 @@
                 {
                   "if": "count(sector[@vocabulary = '$1']) = 1",
                   "then": "not(sector[@vocabulary = '$1']/@percentage) or sector[@vocabulary = '$1']/@percentage = 100",
+                  "paths": ["sector[@vocabulary = '$1']"],
                   "ruleInfo": {
                     "id": "2.1.4",
                     "severity": "",
@@ -573,7 +400,7 @@
               ]
             }
           },
-          "subs": ["if", "then"]
+          "subs": ["if", "then", "paths"]
         }
       ]
     },
@@ -614,7 +441,7 @@
             "id": "12.1.2",
             "severity": "error",
             "category": "geo",
-            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The country percentage value must be 0.0 or positive."
           }
         },
         {
@@ -624,7 +451,7 @@
             "id": "12.1.2",
             "severity": "error",
             "category": "geo",
-            "message": "The country/region percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The region percentage value must be 0.0 or positive."
           }
         },
         {
@@ -644,7 +471,7 @@
             "id": "12.2.2",
             "severity": "error",
             "category": "financial",
-            "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The percentage value must be 0.0 or positive."
           }
         },
         {
@@ -654,7 +481,7 @@
             "id": "12.2.2",
             "severity": "error",
             "category": "financial",
-            "message": "The percentage value must be between 0.0 and 100.0 (inclusive)."
+            "message": "The percentage value must be 0.0 or positive."
           }
         }
       ]
@@ -664,6 +491,7 @@
         {
           "if": "title/narrative",
           "then": "string(title//narrative) != ''",
+          "paths": ["title/narrative"],
           "ruleInfo": {
             "id": "4.3.1",
             "severity": "error",
@@ -674,6 +502,7 @@
         {
           "if": "count(description[not(@type) or @type = '']/narrative) > 0",
           "then": "string(description[not(@type) or @type = '']//narrative) != ''",
+          "paths": ["description[not(@type) or @type = '']/narrative"],
           "ruleInfo": {
             "id": "4.4.1",
             "severity": "error",
@@ -684,6 +513,10 @@
         {
           "if": "count(sector[@vocabulary=98 or @vocabulary=99]) > 0",
           "then": "count(sector[@vocabulary=98 or @vocabulary=99]/narrative) >= count(sector[@vocabulary=98 or @vocabulary=99])",
+          "paths": [
+            "sector[@vocabulary=98 or @vocabulary=99]",
+            "sector[@vocabulary=98 or @vocabulary=99]/narrative"
+          ],
           "ruleInfo": {
             "id": "2.2.1",
             "severity": "error",
@@ -694,6 +527,11 @@
         {
           "if": "count(sector[not(@vocabulary='')]) + count(sector[not(@vocabulary='1')]) > 0",
           "then": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 0",
+          "paths": [
+            "sector[not(@vocabulary='')]",
+            "sector[not(@vocabulary='1')]",
+            "sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "102.1.1",
             "severity": "warning",
@@ -704,6 +542,9 @@
         {
           "if": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) > 1",
           "then": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) = count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage)",
+          "paths": [
+            "sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "2.1.1",
             "severity": "error",
@@ -714,6 +555,9 @@
         {
           "if": "count(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]) = 1",
           "then": "not(sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage) or sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]/@percentage = 100",
+          "paths": [
+            "sector[@vocabulary='' or @vocabulary='1' or not(@vocabulary)]"
+          ],
           "ruleInfo": {
             "id": "2.1.4",
             "severity": "error",
@@ -724,6 +568,7 @@
         {
           "if": "count(sector) > 0",
           "then": "count(transaction/sector) < 1",
+          "paths": ["sector", "transaction/sector"],
           "ruleInfo": {
             "id": "6.6.2",
             "severity": "error",
@@ -734,6 +579,12 @@
         {
           "if": "recipient-country or recipient-region",
           "then": "not(transaction/recipient-country or transaction/recipient-region)",
+          "paths": [
+            "recipient-country",
+            "recipient-region",
+            "transaction/recipient-country",
+            "transaction/recipient-region"
+          ],
           "ruleInfo": {
             "id": "3.6.2",
             "severity": "error",
@@ -744,6 +595,11 @@
         {
           "if": "not(recipient-country or recipient-region)",
           "then": "transaction[recipient-country or recipient-region]",
+          "paths": [
+            "recipient-country",
+            "recipient-region",
+            "transaction[recipient-country or recipient-region]"
+          ],
           "ruleInfo": {
             "id": "3.7.1",
             "severity": "error",
@@ -754,6 +610,11 @@
         {
           "if": "not(recipient-country or recipient-region)",
           "then": "not(transaction[not(recipient-country or recipient-region)])",
+          "paths": [
+            "recipient-country",
+            "recipient-region",
+            "transaction[not(recipient-country or recipient-region)]"
+          ],
           "ruleInfo": {
             "id": "3.7.2",
             "severity": "error",
@@ -764,6 +625,7 @@
         {
           "if": "count(recipient-country) > 1 and not(recipient-region)",
           "then": "count(recipient-country) = count(recipient-country/@percentage)",
+          "paths": ["recipient-country", "recipient-region"],
           "ruleInfo": {
             "id": "3.1.1",
             "severity": "error",
@@ -774,6 +636,7 @@
         {
           "if": "count(recipient-country) = 1 and not(recipient-region)",
           "then": "not(recipient-country/@percentage) or recipient-country/@percentage = 100",
+          "paths": ["recipient-country", "recipient-region"],
           "ruleInfo": {
             "id": "3.1.4",
             "severity": "error",
@@ -814,6 +677,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {
@@ -843,6 +707,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {
@@ -850,16 +715,6 @@
             "severity": "warning",
             "category": "financial",
             "message": "The provider organisation idenitifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["@provider-activity-id"],
-          "ruleInfo": {
-            "id": "1.4.13",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The provider-org activity idenitifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -926,6 +781,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {
@@ -933,16 +789,6 @@
             "severity": "warning",
             "category": "financial",
             "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["@receiver-activity-id"],
-          "ruleInfo": {
-            "id": "1.5.13",
-            "severity": "warning",
-            "category": "financial",
-            "message": "The receiver-org activity idenitifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -978,26 +824,7 @@
     "startswith": {
       "cases": [
         {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["organisation-identifier"],
-          "ruleInfo": {
-            "id": "1.12.8",
-            "severity": "warning",
-            "category": "organisation",
-            "message": "The organisation-identifier must start with an approved agency code."
-          }
-        },
-        {
-          "prefix": "ORG-ID-PREFIX",
-          "paths": ["recipient-org-budget/recipient-org/@ref"],
-          "ruleInfo": {
-            "id": "1.17.8",
-            "severity": "warning",
-            "category": "organisation",
-            "message": "The recipient organisation id must start with an approved agency code."
-          }
-        },
-        {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "prefix": "ORG-ID-PREFIX",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
@@ -1012,6 +839,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["organisation-identifier"],
           "ruleInfo": {
@@ -1022,16 +850,7 @@
           }
         },
         {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["recipient-org-budget/recipient-org/@ref"],
-          "ruleInfo": {
-            "id": "1.17.13",
-            "severity": "warning",
-            "category": "organisation",
-            "message": "The recipient organisation identifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["reporting-org/@ref"],
           "ruleInfo": {
@@ -1129,6 +948,7 @@
     "regex_matches": {
       "cases": [
         {
+          "idCondition": "NOT_EXISTING_ORG_ID",
           "regex": "^[^\\/\\&\\|\\?]+$",
           "paths": ["@ref"],
           "ruleInfo": {
@@ -1136,16 +956,6 @@
             "severity": "warning",
             "category": "participating",
             "message": "The receiver-org idenitifier must not contain any of the symbols /, &, | or ?."
-          }
-        },
-        {
-          "regex": "^[^\\/\\&\\|\\?]+$",
-          "paths": ["@activity-id"],
-          "ruleInfo": {
-            "id": "1.9.13",
-            "severity": "warning",
-            "category": "participating",
-            "message": "The participating-org activity identifier must not contain any of the symbols /, &, | or ?."
           }
         }
       ]
@@ -1184,20 +994,6 @@
             "severity": "error",
             "category": "financial",
             "message": "The start of the period must be before the end of the period."
-          }
-        }
-      ]
-    },
-    "time_limit": {
-      "cases": [
-        {
-          "start": "period-start/@iso-date",
-          "end": "period-end/@iso-date",
-          "ruleInfo": {
-            "id": "7.5.3",
-            "severity": "error",
-            "category": "financial",
-            "message": "Budget Period must not be longer than one year."
           }
         }
       ]

--- a/rulesets/standard.json
+++ b/rulesets/standard.json
@@ -302,6 +302,7 @@
             "strict_sum": {
               "cases": [
                 {
+                  "condition": "count(sector[@vocabulary = '$1']) > 1",
                   "paths": ["sector[@vocabulary = '$1']/@percentage"],
                   "sum": 100,
                   "ruleInfo": {

--- a/schema.json
+++ b/schema.json
@@ -1,469 +1,548 @@
 {
-    "title": "Ruleset",
-    "description": "A set of rules describing constraints on an XML document",
-    "type": "object",
-    "patternProperties": {
-        ".+": {
-            "properties": {
-                "no_more_than_one": {
-                    "description": "There must be no more than one element described by the given paths.",
+  "title": "Ruleset",
+  "description": "A set of rules describing constraints on an XML document",
+  "type": "object",
+  "patternProperties": {
+    ".+": {
+      "properties": {
+        "no_more_than_one": {
+          "description": "There must be no more than one element described by the given paths.",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "atleast_one": {
+          "description": "There must be at least one element described by the given paths.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "one_or_all": {
+          "description": "One must be present or all of the others must be.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "one": {
+                    "type": "string"
+                  },
+                  "all": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "only_one_of": {
+          "description": "Excluded elements must not coexist with selected elements, and only one of these elements must exist.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "excluded": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "if_then": { "$ref": "#/definitions/if_then" },
+        "dependent": {
+          "description": "If one of the provided paths exists, they must all exist.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "sum": {
+          "description": "The numerical sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "sum": {
+                    "type": "number"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "loop": {
+          "description": "Loops through different values of an attribute or element.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "foreach": {
+                    "type": "string"
+                  },
+                  "do": {
                     "type": "object",
                     "additionalProperties": false,
                     "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
+                      "strict_sum": { "$ref": "#/definitions/strict_sum" },
+                      "if_then": { "$ref": "#/definitions/if_then" }
                     }
-                },
-                "atleast_one": {
-                    "description": "There must be at least one element described by the given paths.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "one_or_all": {
-                    "description": "One must be present or all of the others must be.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "one": {
-                                        "type": "string"
-                                    },
-                                    "all": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "only_one_of": {
-                    "description": "Excluded elements must not coexist with selected elements, and only one of these elements must exist.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "excluded": {
-                                        "type": "array",
-                                        "items": {"type":"string"}
-                                    },
-                                    "paths": {
-                                        "type": "array",
-                                        "items": {"type":"string"}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "dependent": {
-                    "description": "If one of the provided paths exists, they must all exist.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "sum": {
-                    "description": "The numerical sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "sum": {
-                                        "type": "number"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "loop": {
-                    "description": "Loops through different values of an attribute or element.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "foreach":{
-                                        "type":"string"
-                                    },
-                                    "do":{
-                                        "type": "object",
-                                        "additionalProperties": false,
-                                        "properties": {
-                                            "strict_sum": {
-                                                "type":"object",
-                                                "additionalProperties": false,
-                                                "properties": {
-                                                    "cases":{
-                                                        "type": "array",
-                                                        "items": {
-                                                            "type": "object",
-                                                            "additionalProperties": false,
-                                                            "properties": {
-                                                                "paths": {
-                                                                    "type": "array",
-                                                                    "items":{"type":"string"}
-                                                                },
-                                                                "sum": {
-                                                                    "type": "number"
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    },
-                                    "subs":{
-                                        "type": "array",
-                                        "items": {"type":"string"}
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "strict_sum": {
-                    "description": "The Decimal sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "sum": {
-                                        "type": "number"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "date_order": {
-                    "description": "The date matched by ``less`` must be less than the date matched by ``more``. If either of these dates is not found, the rule is ignored.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "less": {
-                                        "type": "string"
-                                    },
-                                    "more": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "date_now": {
-                    "description": "Date must not be more recent than the current date.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "date": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "time_limit": {
-                    "description": "Length must be under a year.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "start": {
-                                        "type": "string"
-                                    },
-                                    "end": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "between_dates": {
-                    "description": "Date must be within a defined time period.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "start": {
-                                        "type": "string"
-                                    },
-                                    "end": {
-                                        "type": "string"
-                                    },
-                                    "date": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "regex_matches": {
-                    "description": "The provided ``regex`` must match the text of all elements matched by ``paths``",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "regex": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "regex_no_matches": {
-                    "description": "The provided ``regex`` must match the text of none of the elements matched by ``paths``",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "regex": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "startswith": {
-                    "description": "The text of the each element matched by ``paths`` must start with the text of the element matched by ``start``",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    },
-                                    "start": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "if_then": {
-                    "description": "The ``if`` condition must evaluate to true, otherwise ``then`` must evaluate to true.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "if": {
-                                        "type": "string"
-                                    },
-                                    "then": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "evaluates_to_true": {
-                    "description": "The condition in ``eval`` must evaluate to true.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "eval": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "unique": {
-                    "description": "The text of each of the elements described by ``paths`` must be unique",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "condition": {
-                                        "type": "string"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "range": {
-                    "description": "The value of each of the elements described by ``paths`` must be between the values of ```min`` and ```max```. Min/max can be excluded, to check that the value is at least or no more the specified key.",
-                    "type": "object",
-                    "properties": {
-                        "cases": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "properties": {
-                                    "paths": {
-                                        "type": "array",
-                                        "items":{"type":"string"}
-                                    },
-                                    "min": {
-                                        "type": "number"
-                                    },
-                                    "max": {
-                                        "type": "number"
-                                    }
-                                }
-                            }
-                        }
-                    }
+                  },
+                  "subs": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  }
                 }
-            },
-            "additionalProperties": false
+              }
+            }
+          }
+        },
+        "strict_sum": { "$ref": "#/definitions/strict_sum" },
+        "date_order": {
+          "description": "The date matched by ``less`` must be less than the date matched by ``more``. If either of these dates is not found, the rule is ignored.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "condition": {
+                    "type": "string"
+                  },
+                  "less": {
+                    "type": "string"
+                  },
+                  "more": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "date_now": {
+          "description": "Date must not be more recent than the current date.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "date": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "time_limit": {
+          "description": "Length must be under a year.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "start": {
+                    "type": "string"
+                  },
+                  "end": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "between_dates": {
+          "description": "Date must be within a defined time period.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "start": {
+                    "type": "string"
+                  },
+                  "end": {
+                    "type": "string"
+                  },
+                  "date": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "regex_matches": {
+          "description": "The provided ``regex`` must match the text of all elements matched by ``paths``",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "regex": {
+                    "type": "string"
+                  },
+                  "idCondition": { "$ref": "#/definitions/idCondition" },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "regex_no_matches": {
+          "description": "The provided ``regex`` must match the text of none of the elements matched by ``paths``",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "regex": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "startswith": {
+          "description": "The text of the each element matched by ``paths`` must start with the text of the element matched by ``start``",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "start": {
+                    "type": "string"
+                  },
+                  "idCondition": {
+                    "$ref": "#/definitions/idCondition"
+                  },
+                  "prefix": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "evaluates_to_true": {
+          "description": "The condition in ``eval`` must evaluate to true.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "eval": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "unique": {
+          "description": "The text of each of the elements described by ``paths`` must be unique",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "condition": {
+                    "type": "string"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "range": {
+          "description": "The value of each of the elements described by ``paths`` must be between the values of ```min`` and ```max```. Min/max can be excluded, to check that the value is at least or no more the specified key.",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "min": {
+                    "type": "number"
+                  },
+                  "max": {
+                    "type": "number"
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
+        },
+        "no_spaces": {
+          "description": "The text of each of the elements described by ``paths`` should not start or end with spaces or newlines",
+          "type": "object",
+          "properties": {
+            "cases": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "paths": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                }
+              }
+            }
+          }
         }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "idCondition": {
+      "type": "string",
+      "enum": ["NOT_EXISTING_ORG_ID_PREFIX", "NOT_EXISTING_ORG_ID"]
     },
-    "additionalProperties": false
+    "ruleInfo": {
+      "type": "object",
+      "description": "Information about the rule used by the validator",
+      "required": ["id", "severity", "category", "message"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identifier of the error",
+          "examples": ["9.26.1", "9.42.1"]
+        },
+        "severity": {
+          "type": "string",
+          "enum": ["critical", "error", "warning"],
+          "description": "The severity level of the error"
+        },
+        "category": {
+          "type": "string",
+          "enum": [
+            "iati",
+            "identifiers",
+            "organisation",
+            "information",
+            "participating",
+            "geo",
+            "classifications",
+            "financial",
+            "documents",
+            "relations",
+            "performance"
+          ],
+          "description": "The category of the validation error"
+        },
+        "message": {
+          "type": "string",
+          "description": "The informational message about the validation error"
+        }
+      }
+    },
+    "if_then": {
+      "description": "The ``if`` condition must evaluate to true, otherwise ``then`` must evaluate to true.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "if": {
+                "type": "string"
+              },
+              "then": {
+                "type": "string"
+              },
+              "paths": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+            }
+          }
+        }
+      }
+    },
+    "strict_sum": {
+      "description": "The Decimal sum of the values of elements matched by ``paths`` must match the value for the ``sum`` key.",
+      "type": "object",
+      "properties": {
+        "cases": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "paths": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "sum": {
+                "type": "number"
+              },
+              "condition": {
+                "type": "string"
+              },
+              "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+            }
+          }
+        }
+      }
+    }
+  }
 }

--- a/schema.json
+++ b/schema.json
@@ -492,6 +492,20 @@
         "message": {
           "type": "string",
           "description": "The informational message about the validation error"
+        },
+        "link": {
+          "type": "object",
+          "description": "Link to related website guidance on the error",
+          "properties": {
+            "url": {
+              "type": "string",
+              "description": "Full url to the guidance"
+            },
+            "path": {
+              "type": "string",
+              "description": "Path to be added on the the base url of the iati standard documentation e.g. https://iatistandard.org/en/iati-standard/{version}/{path}"
+            }
+          }
         }
       }
     },

--- a/schema.json
+++ b/schema.json
@@ -350,7 +350,10 @@
                     "type": "array",
                     "items": { "type": "string" }
                   },
-                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" }
+                  "ruleInfo": { "$ref": "#/definitions/ruleInfo" },
+                  "separator": {
+                    "type": "string"
+                  }
                 }
               }
             }


### PR DESCRIPTION
## Summary
- As part of the V2 Validator work, the JSON-based rules have been enhanced and some additional checks and feedback messages have been added in line with the IATI Standard. See `SPEC_JS.rst` for more detail.
- This PR is planned to be merged the week of 13 September.

## Details

- 12.3.2 sector % range
- 12.1.1 recipient-region/country range
- 12.2.1 capital-spend and budget-item range
- fix ids to .2
- updates for validator V2
- merge major updates learned from v2.03
- fix incorrectly placed rules in JSON
- schema updates and push to redis workflow
- remove 7.5.2 as it duplicates Schema check
- add job to trigger csv update on rule tracker repo
- fix spelling errors with identifier
- replace rule 1.1.1 with 1.1.21
- update schema for new rule
- add file commit sha into redis call
- add support for guidance links
- push rulesets to PROD redis-cacher
- updates for validator v2
- remove reference to Readme.md
